### PR TITLE
changed some details 

### DIFF
--- a/liquidprompt.bash
+++ b/liquidprompt.bash
@@ -141,7 +141,7 @@ fi
 # get cpu number
 __cpunum_Linux()
 {
-    grep ^processor /proc/cpuinfo | wc -l
+    grep ^[Pp]rocessor /proc/cpuinfo | wc -l
 }
 
 __cpunum_FreeBSD()


### PR DESCRIPTION
Two fix/change : 
- The use of __shorten_path instead of \w made the ~ when we're in the home dir disappear.
- On one of my machine the /proc/cpuinfo descibre my processor with a capital P. The proc counting function counted then 0 which made the prompt execute a zero division.
