### PR TITLE
Use the REVERSE variable to use black on white

### DIFF
--- a/liquidprompt.bash
+++ b/liquidprompt.bash
@@ -702,7 +702,7 @@ __set_bash_prompt()
     __USER=$(__user)
     __HOST=$(__host_color)
     __PERM=$(__permissions_color)
-     __PWD=$(__shorten_path $PWD $PATH_LENGTH)
+     __PWD=$(__shorten_path "$PWD" $PATH_LENGTH)
 
     # right of main prompt: space at left
      __GIT=$(__sl "$(__git_branch_color)")


### PR DESCRIPTION
Having to edit the liquidprompt.bash file to select a configuration is a
bad idea. Configuration shall be external to the file to avoid any
modification compared to the official version.

It is easy to pass paramaters to the script by using (in the present case):
$ REVERSE="1" source liquidprompt.bash
