### PR TITLE
Debug for c46f027

### DIFF
--- a/liquidprompt.bash
+++ b/liquidprompt.bash
@@ -708,6 +708,9 @@ __sb()
 
 __set_bash_prompt()
 {
+    # execute the old prompt
+    $LP_OLD_PROMPT_COMMAND
+
     # as this get the last returned code, it should be called first
     __RET=$(__sl "$(__return_value $?)")
 
@@ -761,11 +764,7 @@ prompt_on()
 {
     LP_OLD_PS1="$PS1"
     LP_OLD_PROMPT_COMMAND="$PROMPT_COMMAND"
-    if [[ -z "$PROMPT_COMMAND" ]] ; then
-        PROMPT_COMMAND=__set_bash_prompt
-    else
-        PROMPT_COMMAND=$PROMPT_COMMAND;__set_bash_prompt
-    fi
+    PROMPT_COMMAND=__set_bash_prompt
 }
 
 # Come back to the old prompt


### PR DESCRIPTION
PROMPT_COMMAND
  If set, the value is executed as a command prior to issuing each
  primary prompt.

PROMPT_COMMAND cannot contain a script but only ONE command (at least on
bash 3.2.48 from Mac OS X Lion)

The solution is to call the old prompt command at the start of
__set_bash_prompt()
