### PR TITLE
Fix bug : Shell detection 

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -37,7 +37,7 @@
 
 # See the README.md file for a summary of features.
 
-_LP_WORKING_SHELL=${SHELL##*/}
+_LP_WORKING_SHELL=$(ps -p $$ | awk '{n=$NF}END{print n}')
 
 # A login shell starts with a "-"
 if [[ "$_LP_WORKING_SHELL" == "-bash" ]]; then


### PR DESCRIPTION
This reverts commit 7e8fc0e01fb6b366938b680eebc8fb6771cc9a08.

Conflicts:
    liquidprompt

This commit introduced ${SHELL##_/} as shell detection but it does'nt work if you change your shell (default is zsh) :
⏚ [luc:~/tmp/liquidprompt] master ± echo ${SHELL##_/}
zsh
⏚ [luc:~/tmp/liquidprompt] master ± bash
luc@macld:~/tmp/liquidprompt$ echo ${SHELL##*/}
zsh
