### PR TITLE
Fix shell detection

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -37,17 +37,8 @@
 
 # See the README.md file for a summary of features.
 
-_LP_WORKING_SHELL=${SHELL##*/}
-
-# A login shell starts with a "-"
-if [[ "$_LP_WORKING_SHELL" == "-bash" ]]; then
-    _LP_WORKING_SHELL="bash"
-fi
-
-if [[ "$_LP_WORKING_SHELL" == "bash" ]]; then
-    # Check for recent enough version of bash.
-    [[ -z "$BASH_VERSION" || -z "$PS1" || -z "$TERM" ]] && return;
-
+# Check for recent enough version of bash.
+if test -n "$BASH_VERSION" -a -n "$PS1" -a -n "$TERM" ; then
     bash=${BASH_VERSION%.*}; bmajor=${bash%.*}; bminor=${bash#*.}
     if [[ $bmajor -lt 3 ]] || [[ $bmajor -eq 3 && $bminor -lt 2 ]]; then
         unset bash bmajor bminor
@@ -55,15 +46,20 @@ if [[ "$_LP_WORKING_SHELL" == "bash" ]]; then
     fi
     unset bash bmajor bminor
 
+	_LP_WORKING_SHELL=bash
     _LP_OPEN_ESC="\["
     _LP_CLOSE_ESC="\]"
     _LP_USER_SYMBOL="\u"
     _LP_HOST_SYMBOL="\h"
-elif [[ "$_LP_WORKING_SHELL" == "zsh" ]]; then
+elif test -n "$ZSH_VERSION" ; then
+	_LP_WORKING_SHELL=zsh
     _LP_OPEN_ESC="%{"
     _LP_CLOSE_ESC="%}"
     _LP_USER_SYMBOL="%n"
     _LP_HOST_SYMBOL="%m"
+else
+	echo "liquidprompt: shell not supported" >&2
+	return
 fi
 
 
@@ -933,8 +929,6 @@ prompt_on()
             LP_OLD_PROMPT_COMMAND="$PROMPT_COMMAND"
         elif [[ "$_LP_WORKING_SHELL" == "zsh" ]]; then
             LP_OLD_PROMPT_COMMAND="$precmd"
-        else
-            echo "${RED}Shell $_LP_WORKING_SHELL not supported $NO_COL"
         fi
     fi
     if [[ "$_LP_WORKING_SHELL" == "bash" ]]; then


### PR DESCRIPTION
Faster detection based only on BASH_VERSION/ZSH_VERSION variables.
Fixes shell detection (sub shell detection broken in 7e8fc0e).
Should better fail when started with an other shell than bash/zsh.

So do not apply the revert proposed in #33.
