### PR TITLE
Refactor OS specific code

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -146,7 +146,7 @@ fi
 
 # Get cpu count
 case "$LP_OS" in
-    Linux)   _lp_CPUNUM=$( nproc || grep -c '^[Pp]rocessor' /proc/cpuinfo ) ;;
+    Linux)   _lp_CPUNUM=$( nproc 2>/dev/null || grep -c '^[Pp]rocessor' /proc/cpuinfo ) ;;
     FreeBSD) _lp_CPUNUM=$( sysctl -n hw.ncpu ) ;;
     SunOS)   _lp_CPUNUM=$( kstat -m cpu_info | grep -c "module: cpu_info" ) ;;
 esac


### PR DESCRIPTION
Refactoring OS specific code:
- merge Darwin with FreeBSD
- refactor _lp_CPUNUM without functions
- use a single function for _lp_cpu_load
- refactor _lp_load_color to avoid using LP_OS
- other optimizations in _lp_load_color (more to do)
- now that LP_OS is not used at runtime, unset LP_OS before runtime
