### PR TITLE
Fix a revert in eec94d1d by reapplying 7f2ed35c

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -762,8 +762,8 @@ _lp_battery_color()
 {
     [[ "$LP_ENABLE_BATT" != 1 ]] && return
 
-    local mark=$LP_BATTERY_MARK
-    local chargingmark=$LP_ADAPTER_MARK
+    local mark=$LP_MARK_BATTERY
+    local chargingmark=$LP_MARK_ADAPTER
     local bat
     local ret
     bat=$(_lp_battery)


### PR DESCRIPTION
In eec94d1db8d2a87b10c1034429f44c00bffc1be8 (which is about the time feature) it looks like 7f2ed35c414cbb5b34ea50ac8867fa58311ff4fb has been reverted (probably a merge error).
This patch reapplies it.
