### PR TITLE
Fails on Mac OS X (again): tput: unknown terminfo capability 'AF'

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -72,7 +72,7 @@ fi
 case $(uname) in
     FreeBSD)   LP_OS=FreeBSD ;;
     DragonFly) LP_OS=FreeBSD ;;
-    Darwin)    LP_OS=FreeBSD ;;
+    Darwin)    LP_OS=Darwin  ;;
     SunOS)     LP_OS=SunOS   ;;
     *)         LP_OS=Linux   ;;
 esac
@@ -147,7 +147,7 @@ fi
 # Get cpu count
 case "$LP_OS" in
     Linux)   _lp_CPUNUM=$( nproc 2>/dev/null || grep -c '^[Pp]rocessor' /proc/cpuinfo ) ;;
-    FreeBSD) _lp_CPUNUM=$( sysctl -n hw.ncpu ) ;;
+    FreeBSD|Darwin) _lp_CPUNUM=$( sysctl -n hw.ncpu ) ;;
     SunOS)   _lp_CPUNUM=$( kstat -m cpu_info | grep -c "module: cpu_info" ) ;;
 esac
 
@@ -161,7 +161,7 @@ case "$LP_OS" in
             echo "$load"
         }
         ;;
-    FreeBSD)
+    FreeBSD|Darwin)
         _lp_cpu_load () {
             local bol load eol
             read bol load eol < $<( LANG=C sysctl -n vm.loadavg )


### PR DESCRIPTION
The Colors declarations for Darwin should use the Linux method and NOT
the FreeBSD method or you get errors:
tput: unknown terminfo capability 'AF'
