### PR TITLE
Add support of /etc/debian_chroot

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -677,13 +677,15 @@ _lp_svn_branch()
     [[ "$LP_ENABLE_SVN" != 1 ]] && return
     local root
     local url
+    local result
     eval $(LANG=C LC_ALL=C svn info 2>/dev/null | sed -n 's/^URL: \(.*\)/url="\1"/p;s/^Repository Root: \(.*\)/root="\1"/p' )
     # Make url relative to root
     url="${url:${#root}}"
     if [[ "$url" == */trunk* ]] ; then
         echo trunk
     else
-        expr "$url" : '.*/branches/\([^/]*\)' || expr "$url" : '/\([^/]*\)' || basename "$root"
+        result=$(expr "$url" : '.*/branches/\([^/]*\)' || expr "$url" : '/\([^/]*\)' || basename "$root")
+        echo $result
     fi
 }
 


### PR DESCRIPTION
Debian uses the file /etc/debian_chroot to give a name to a chroot.
The default /etc/bash.bashrc contains:

if [ -z "${debian_chroot:-}" ] && [ -r /etc/debian_chroot ]; then
    debian_chroot=$(cat /etc/debian_chroot)
fi

PS1='${debian_chroot:+($debian_chroot)}\u@\h:\w\$ '

I have no idea if and how the other distributions implement the same feature.
