### PR TITLE
Added conditionnal support for bash_completion

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -1039,7 +1039,7 @@ prompt_on()
 
     #If bash completion is installed, use it
     if [ -f /etc/bash_completion ];
-	then source /etc/bash_completion
+        then source /etc/bash_completion
     fi
 
     # Keep in mind that LP has been sourced


### PR DESCRIPTION
This add conditional support for bash_completion. 

If bash_completion is not installed or not found, nothing happens. If it is found in /etc/bash_completion, it is sourced.
