### PR TITLE
fix git in a directory containing spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ building:
 * `LP_ENABLE_SVN`, if you want to have subversion informations
 * `LP_ENABLE_HG`, if you want to have mercurial informations
 
+Or enable, to use features disabled by default
+* `LP_ENABLE_VCS_ROOT`, if you want to show VCS informations with root account
+
 Note that if required commands are not installed, enabling the
 corresponding feature will have no effect.
 Note also that all the `LP_ENABLE_…` variables override the templates,

--- a/liquidprompt
+++ b/liquidprompt
@@ -200,6 +200,7 @@ _lp_source_config()
     LP_ENABLE_SVN=${LP_ENABLE_SVN:-1}
     LP_ENABLE_HG=${LP_ENABLE_HG:-1}
     LP_ENABLE_TIME=${LP_ENABLE_TIME:-0}
+    LP_ENABLE_VCS_ROOT=${LP_ENABLE_VCS_ROOT:-0}
 
     LP_MARK_BATTERY=${LP_MARK_BATTERY:-"⌁"}
     LP_MARK_ADAPTER=${LP_MARK_ADAPTER:-"⏚"}
@@ -974,9 +975,11 @@ _lp_set_prompt()
     LP_PROXY="${LP_COLOR_PROXY}$(_lp_proxy)${NO_COL}"
 
     # right of main prompt: space at left
-     LP_GIT=$(_lp_sl "$(_lp_git_branch_color)")
-      LP_HG=$(_lp_sl "$(_lp_hg_branch_color)")
-     LP_SVN=$(_lp_sl "$(_lp_svn_branch_color)")
+    if [[ "$EUID" -ne "0" ]] || [[ "$LP_ENABLE_VCS_ROOT" = "1" ]] ; then
+        LP_GIT=$(_lp_sl "$(_lp_git_branch_color)")
+         LP_HG=$(_lp_sl "$(_lp_hg_branch_color)")
+        LP_SVN=$(_lp_sl "$(_lp_svn_branch_color)")
+    fi
 
     # end of the prompt line: double spaces
     LP_MARK=$(_lp_sb "$(_lp_smart_mark)")
@@ -1004,7 +1007,9 @@ _lp_set_prompt()
         else
             # path in yellow
             PS1="${PS1}${LP_PWD}]${LP_PROXY}"
-            # do not add VCS infos
+            # do not add VCS infos unless told otherwise (LP_ENABLE_VCS_ROOT)
+            [[ "$LP_ENABLE_VCS_ROOT" = "1" ]] && \
+                PS1="${PS1}${LP_GIT}${LP_HG}${LP_SVN}"
         fi
         # add return code and prompt mark
         PS1="${PS1}${LP_ERR}${LP_MARK}"

--- a/liquidpromptrc-dist
+++ b/liquidpromptrc-dist
@@ -52,6 +52,10 @@ LP_ENABLE_LOAD=1
 # Recommended value is 1
 LP_ENABLE_BATT=1
 
+# Do you want to use vcs features with root account
+# Recommended value is 0
+LP_ENABLE_VCS_ROOT=0
+
 # Do you want to use the git special features ?
 # Recommended value is 1
 LP_ENABLE_GIT=1


### PR DESCRIPTION
Hi,
When using liquidprompt in a git path containing spaces (like in a remote share mounted via GVFS : ~/.gvfs/myshare on myserver/path/to/my/git/repo), I've got errors like this one : 

```
basename: extra operand `myserver/path/to/my/git/repo'
```

Here is a quick fix.
Thanks for this useful tool.
