### PR TITLE
No line return in a git repository

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -563,7 +563,7 @@ _lp_git_branch()
 
     topdir="$(git rev-parse --git-dir 2>/dev/null)"
     if [[ -n "$topdir" ]] && [[ "$(basename $topdir)" == '.git' ]]  && [[ ! -z "$(git branch)" ]] ; then
-        echo -n "$(git branch 2>/dev/null | sed -n '/^\*/s/^\* //p;')"
+        echo -n "$(git branch --no-color 2>/dev/null | sed -n '/^\*/s/^\* //p;')"
     fi
 }
 


### PR DESCRIPTION
Line return (when cursor reach the last column of the term) don't work in git repository if user use git colored output (ui.color = 1 and color.ui = always).
