### PR TITLE
VCS with root account

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ building:
 * `LP_ENABLE_GIT`, if you want to have git informations
 * `LP_ENABLE_SVN`, if you want to have subversion informations
 * `LP_ENABLE_HG`, if you want to have mercurial informations
+* `LP_ENABLE_VCS_ROOT`, if you want to show VCS informations with root account
 
 Note that if required commands are not installed, enabling the
 corresponding feature will have no effect.

--- a/liquidprompt
+++ b/liquidprompt
@@ -201,7 +201,8 @@ _lp_source_config()
     LP_ENABLE_HG=${LP_ENABLE_HG:-1}
     LP_ENABLE_TIME=${LP_ENABLE_TIME:-0}
     LP_ENABLE_VIRTUALENV=${LP_ENABLE_VIRTUALENV:-1}
-    
+    LP_ENABLE_VCS_ROOT=${LP_ENABLE_VCS_ROOT:-0}
+
     LP_MARK_BATTERY=${LP_MARK_BATTERY:-"⌁"}
     LP_MARK_ADAPTER=${LP_MARK_ADAPTER:-"⏚"}
     LP_MARK_LOAD=${LP_MARK_LOAD:-"⌂"}
@@ -1000,7 +1001,7 @@ _lp_set_prompt()
 
     # right of main prompt: space at left
     LP_VENV=$(_lp_sl "$(_lp_virtualenv)")
-    if [[ "$EUID" -ne "0" ]] ; then
+    if [[ "$EUID" -ne "0" ]] || [[ "$LP_ENABLE_VCS_ROOT" = "1" ]] ; then
         LP_GIT=$(_lp_sl "$(_lp_git_branch_color)")
          LP_HG=$(_lp_sl "$(_lp_hg_branch_color)")
         LP_SVN=$(_lp_sl "$(_lp_svn_branch_color)")
@@ -1032,7 +1033,9 @@ _lp_set_prompt()
         else
             # path in yellow
             PS1="${PS1}${LP_PWD}]${LP_VENV}${LP_PROXY}"
-            # do not add VCS infos
+            # do not add VCS infos unless told otherwise (LP_ENABLE_VCS_ROOT)
+            [[ "$LP_ENABLE_VCS_ROOT" = "1" ]] && \
+                PS1="${PS1}${LP_GIT}${LP_HG}${LP_SVN}"
         fi
         # add return code and prompt mark
         PS1="${PS1}${LP_ERR}${LP_MARK}"

--- a/liquidpromptrc-dist
+++ b/liquidpromptrc-dist
@@ -57,6 +57,10 @@ LP_ENABLE_LOAD=1
 # Recommended value is 1
 LP_ENABLE_BATT=1
 
+# Do you want to use vcs features with root account
+# Recommended value is 0
+LP_ENABLE_VCS_ROOT=0
+
 # Do you want to use the git special features ?
 # Recommended value is 1
 LP_ENABLE_GIT=1


### PR DESCRIPTION
Same as my previous branch named `enable_vcs_feature_for_root` but rebased on your develop branch and splitted in two commits :
- don't process VCS function if root, they do not appear in the result anyway, and they can be quite slow
- LP_ENABLE_VCS_ROOT to enable use of VCS features with root

I hope I didn't
