### PR TITLE
some fixes and optimization 

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -1055,7 +1055,7 @@ _lp_load_color()
     if [[ $load -ge $LP_LOAD_THRESHOLD ]]
     then
         local ret
-        ret="${LP_MARK_LOAD}${NO_COL}"
+        ret="${LP_MARK_LOAD}"
         if   [[ $load -ge 0   ]] && [[ $load -lt 20  ]] ; then
             ret="${ret}${LP_COLORMAP_0}"
         elif [[ $load -ge 20  ]] && [[ $load -lt 40  ]] ; then


### PR DESCRIPTION
- deletion of useless NO_COLs (making $PS1 longer than needed)
- optimizing _lp_time by using built-in vars
- not recalculating darwin kernel version at each prompt set
- I also made changes so LP_USER would be define at load time and not at each prompt set.
