### PR TITLE
Fix custom.ps1 sourcing

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -1299,6 +1299,8 @@ _lp_set_prompt()
         esac
     fi
 
+    source $LP_PS1_FILE
+
     if [[ -z $LP_PS1 ]] ; then
         # add title escape time, jobs, load and battery
         PS1="${LP_PS1_PREFIX}${LP_TIME}${LP_BATT}${LP_LOAD}${LP_JOBS}"

--- a/liquidpromptrc-dist
+++ b/liquidpromptrc-dist
@@ -6,7 +6,7 @@
 # If you want to use different themes and features,
 # you can load the corresponding files here:
 #source ~/code/liquidprompt/nojhan.theme
-#source ~/code/liquidprompt/nojhan.ps1
+#LP_PS1_FILE="~/code/liquidprompt/nojhan.ps1"
 
 #############
 # BEHAVIOUR #


### PR DESCRIPTION
If I do as said in the liquidpromptrc-dist to have a custom ps1 (ie sourcing ps1 file in rc file), I got these errors (zsh and bash) :

``` bash
/etc/zsh/liquid.ps1:47: command not found: _lp_title
[  ]bash
luc@eddard:~$ source /etc/zsh/liquidprompt 
bash: _lp_title : commande introuvable
[  ]
```

The problem is using _lp_title and variables before their declaration and assignations since the rc file is sourced at the beginning of liquidprompt.

I propose to set a `LP_PS1_FILE` in the rc file, instead of sourcing it directly and to source it in after all the work.

If I'm not clear (I'm not sure to be able to read this and undertand myself), please have a look at the commit : code never lies :)
