### PR TITLE
Handle remote sessions that have changed user

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -255,6 +255,7 @@ _lp_source_config()
     LP_COLOR_USER_ROOT=${_ROOT:-$BOLD_YELLOW}
     LP_COLOR_HOST=${LP_COLOR_HOST:-""}
     LP_COLOR_SSH=${LP_COLOR_SSH:-$BLUE}
+    LP_COLOR_SU=${LP_COLOR_SU:-$BOLD_YELLOW}
     LP_COLOR_TELNET=${LP_COLOR_TELNET:-$WARN_RED}
     LP_COLOR_X11_ON=${LP_COLOR_X11:-$GREEN}
     LP_COLOR_X11_OFF=${LP_COLOR_X11:-$YELLOW}
@@ -353,13 +354,16 @@ fi
 
 _lp_connection()
 {
-    if [[ -n "$SSH_CLIENT$SSH2_CLIENT" ]] ; then
+    if [[ -n "$SSH_CLIENT$SSH2_CLIENT$SSH_TTY" ]] ; then
         echo ssh
     else
         # TODO check on *BSD
         local sess_src=$(who am i | sed -n 's/.*(\(.*\))/\1/p')
+        local sess_parent=$(ps -o comm= -p $PPID)
         if [[ -z "$sess_src" || "$sess_src" = ":"* ]] ; then
             echo lcl  # Local
+        elif [[ "$sess_parent" = "su" || "$sess_parent" = "sudo" ]] ; then
+            echo su   # Remote su/sudo
         else
             echo tel  # Telnet
         fi
@@ -414,6 +418,9 @@ ssh)
         # the same color for all hosts
         LP_HOST="${LP_HOST}${LP_COLOR_SSH}${_LP_HOST_SYMBOL}${NO_COL}"
     fi
+    ;;
+su)
+    LP_HOST="${LP_HOST}${LP_COLOR_SU}${_LP_HOST_SYMBOL}${NO_COL}"
     ;;
 tel)
     LP_HOST="${LP_HOST}${LP_COLOR_TELNET}${_LP_HOST_SYMBOL}${NO_COL}"


### PR DESCRIPTION
Previously, if you were connected via SSH but had changed user with
su/sudo, the _lp_connection function would report you as being connected
via telnet. Now, if the parent process of your shell is 'su' or 'sudo',
it sets the hostname to the color LP_COLOR_SU (default: bold yellow).

This is probably only useful for people who have installed liquidprompt
in a global location and run it with a globally-accessible shell config
(/etc/profile or similar). But since there's already code to handle a
current user of 'root', I assume this has already happened.

It may be prudent to use the parent-process checking code for telnet
checking as well (rather than the 'who am i | sed') method, but I didn't
want to reach too far into existing code... plus, I don't have any servers
with telnetd running to test.

(Assistance from Gilles in http://unix.stackexchange.com/questions/9605/how-can-i-detect-if-the-shell-is-controlled-from-ssh)
