### PR TITLE
Fix bad regex in _lp_git_branch

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -684,7 +684,7 @@ _lp_git_branch()
     [[ "$LP_ENABLE_GIT" != 1 ]] && return
     local gitdir
     gitdir="$(git rev-parse --git-dir 2>/dev/null)"
-    [[ $? -ne 0 || $gitdir =~ '*/.git*' ]] && return
+    [[ $? -ne 0 || $gitdir =~ '.*/.git.*' ]] && return
     local branch="$(git symbolic-ref HEAD 2>/dev/null)"
     if [[ $? -ne 0 || -z "$branch" ]] ; then
         # In detached head state, use commit instead


### PR DESCRIPTION
I got some errors with latest develop :

```
 _lp_git_branch:5: failed to compile regex: Expression régulière précédente invalide
```

Here's a fix
