### PR TITLE
Fix bad regex for submodule from #118

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -684,7 +684,7 @@ _lp_git_branch()
     [[ "$LP_ENABLE_GIT" != 1 ]] && return
     local gitdir
     gitdir="$(git rev-parse --git-dir 2>/dev/null)"
-    [[ $? -ne 0 || $gitdir =~ '*/.git*' ]] && return
+    [[ $? -ne 0 || ! $gitdir =~ (.*\/)?\.git.* ]] && return
     local branch="$(git symbolic-ref HEAD 2>/dev/null)"
     if [[ $? -ne 0 || -z "$branch" ]] ; then
         # In detached head state, use commit instead


### PR DESCRIPTION
The regex in bash and zsh doesn't need to be quoted. It resulted a
bad regex warning in zsh (#127) and it didn't worked in submodule.
Plus, bash and zsh regexes have perlish syntax.
Related to #118 
