### PR TITLE
fixing issue #132

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -1151,6 +1151,7 @@ _lp_load_color()
     [[ "$LP_ENABLE_LOAD" != 1 ]] && return
 
     local load
+    local IFS=" \t\n"
     load="$(_lp_cpu_load | sed 's/\.//g;s/^0*//g' )"
     let "load=${load:-0}/$_lp_CPUNUM"
 


### PR DESCRIPTION
Fixing issue #132 by forcing a certain value (the default one: `<space><tab><newline>`) for `IFS` in `_lp_load_color`.

I didn't get any other error than those pointed in issue #132 while using this fix in bash and changing `IFS` but I didn't test the entire prompt. Some other behavior might persist with non default `IFS`.
