### PR TITLE
Only show the branch specifier if the current directory is part of a git repo

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -685,7 +685,7 @@ _lp_git_branch()
 {
     [[ "$LP_ENABLE_GIT" != 1 ]] && return
     local gitdir
-    gitdir="$(git rev-parse --git-dir 2>/dev/null)"
+    gitdir="$([ $(git ls-files . 2>/dev/null | wc -l) -gt 0 ] && git rev-parse --git-dir 2>/dev/null)"
     [[ $? -ne 0 || ! $gitdir =~ (.*\/)?\.git.* ]] && return
     local branch="$(git symbolic-ref HEAD 2>/dev/null)"
     if [[ $? -ne 0 || -z "$branch" ]] ; then


### PR DESCRIPTION
I couldn't come up with an alternate method of doing this. It works for empty directories (since you can't have a truly empty directory in git). 
I personally use this because my home folder is a git repo.
