### PR TITLE
Use print -P for zsh prompts

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -545,9 +545,9 @@ _lp_shorten_path()
         fi
     elif [[ "$_LP_WORKING_SHELL" == "zsh" ]]; then
         if [[ "$len" -gt "$max_len" ]]; then
-            echo "%-${keep}~%${max_len}<${mask}<%~%<<"
+            print -P "%-${keep}~%${max_len}<${mask}<%~%<<"
         else
-            echo "%~"
+            print -P "%~"
         fi
     fi
 }


### PR DESCRIPTION
echo doesn't properly handle %~ expansion. print -P however, does what we need.

There may be some weirdness still when using zprezto or oh-my-zsh, but that's due to something they're doing.
