### PR TITLE
Optimize _lp_shorten_path by using bash/zsh features

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -462,42 +462,40 @@ _lp_proxy()
 _lp_shorten_path()
 {
     if [[ "$LP_ENABLE_SHORTEN_PATH" != 1 || -n "$PROMPT_DIRTRIM" ]] ; then
-        if [[ "$_LP_WORKING_SHELL" == "bash" ]]; then
+        if [[ "$_LP_WORKING_SHELL" == bash ]]; then
             echo "\\w"
         else
-            echo "$(print -P "%~")"
+            print -P '%~'
         fi
         return
     fi
-    # the character that will replace the part of the path that is masked
-    local mask="$LP_MARK_SHORTEN_PATH"
-    # index of the directory to keep from the root (starts at 0 whith bash, 1 with zsh)
-    local keep=$((LP_PATH_KEEP-1))
-    if [[ "$_LP_WORKING_SHELL" == "zsh" ]]; then
-       keep=$LP_PATH_KEEP
-    fi
 
     local p="${PWD/$HOME/~}"
-    local len="${#p}"
+    local -i len=${#p}
+    local -i max_len=$((${COLUMNS:-80}*$LP_PATH_LENGTH/100))
 
-    local max_len=$((${COLUMNS:-80}*$LP_PATH_LENGTH/100))
-    local mask_len="${#mask}"
-    local slashes=0
-
-    if [[ "$_LP_WORKING_SHELL" == "bash" ]]; then
-        if [[ "$len" -gt "$max_len" ]]
+    if [[ "$_LP_WORKING_SHELL" == bash ]]; then
+        if (( len > max_len ))
         then
+            # index of the directory to keep from the root
+            # (starts at 0 whith bash, 1 with zsh)
+            local -i keep=LP_PATH_KEEP-1
+            # the character that will replace the part of the path that is
+            # masked
+            local mask="$LP_MARK_SHORTEN_PATH"
+            local -i mask_len=${#mask}
             # finds all the '/' in
             # the path and stores their
             # positions
             #
             local pos=()
+            local -i slashes=0
             for ((i=0;i<len;i++))
             do
-                if [[ "${p:i:1}" == "/" ]]
+                if [[ "${p:i:1}" == / ]]
                 then
                     pos=(${pos[@]} $i)
-                    slashes=$((${slashes}+1))
+                    let slashes++
                 fi
             done
             pos=(${pos[@]} $len)
@@ -506,49 +504,49 @@ _lp_shorten_path()
             # left-most that doesn't break the
             # length limit
             #
-            local i=$keep
-            if [[ $keep > $slashes ]] ; then
-                i=$slashes
+            local -i i=keep
+            if (( keep > slashes )) ; then
+                i=slashes
             fi
-            while [[ "$((len-pos[i]))" -gt "$((max_len-mask_len))" ]]
+            while (( len-pos[i] > max_len-mask_len ))
             do
-                i=$((i+1))
+                let i++
             done
 
             # let us check if it's OK to
             # print the whole thing
             #
-            if [[ "${pos[i]}" -eq "0" ]]
+            if (( pos[i] == 0 ))
             then
                 # the path is shorter than
                 # the maximum allowed length,
-                # so no need for ...
+                # so no need for '…'
                 #
                 echo "$p"
 
-            elif [[ "${pos[i]}" = "$len" ]]
+            elif (( pos[i] == len ))
             then
                 # constraints are broken because
                 # the maximum allowed size is smaller
                 # than the last part of the path, plus
                 # ' … '
                 #
-                echo "${p:0:((${pos[${keep}]}+1))}${mask}${p:((len-max_len+mask_len))}"
+                echo "${p:0:pos[keep]+1}${mask}${p:len-max_len+mask_len}"
             else
                 # constraints are satisfied, at least
                 # some parts of the path, plus ' … ', are
                 # shorter than the maximum allowed size
                 #
-                echo "${p:0:((${pos[${keep}]}+1))}${mask}${p:pos[i]}"
+                echo "${p:0:pos[keep]+1}${mask}${p:pos[i]}"
             fi
         else
             echo "$p"
         fi
-    elif [[ "$_LP_WORKING_SHELL" == "zsh" ]]; then
-        if [[ "$len" -gt "$max_len" ]]; then
-            echo "%-${keep}~%${max_len}<${mask}<%~%<<"
+    else # [[ "$_LP_WORKING_SHELL" == zsh ]]
+        if (( len > max_len )); then
+            echo "%-${LP_PATH_KEEP}~%${max_len}<${LP_MARK_SHORTEN_PATH}<%~%<<"
         else
-            echo "%~"
+            echo '%~'
         fi
     fi
 }


### PR DESCRIPTION
Optimizations:
- move variable declaration in blocks where they will be used
  (so they are not computed in blocks where they are not used)
- `local -i` for integer variables
- `if [[ $(( ... )) -gt $(( ... )) ]]`   ==>  `if (( ... > ... ))`
- `i=$((i+1))`   ==>  `let i++`

As a side effect the readability of the code is improved.
