### PR TITLE
Fix and optimize colored brackets for terminal multiplexer

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -321,6 +321,12 @@ unset _lp_source_config
 [[ "$LP_ENABLE_BZR"  = 1 ]] && { command -v bzr > /dev/null || LP_ENABLE_BZR=0  ; }
 [[ "$LP_ENABLE_BATT" = 1 ]] && { command -v acpi >/dev/null || LP_ENABLE_BATT=0 ; }
 
+# If we are running in a terminal multiplexer, brackets are colored
+if [[ "$TERM" == screen* ]]; then
+    LP_MARK_BRACKET_OPEN="${LP_COLOR_IN_MULTIPLEXER}${LP_MARK_BRACKET_OPEN}${NO_COL}"
+    LP_MARK_BRACKET_CLOSE="${LP_COLOR_IN_MULTIPLEXER}${LP_MARK_BRACKET_CLOSE}${NO_COL}"
+fi
+
 # Escape the given strings
 # Must be used for all strings that may comes from remote sources,
 # like VCS branch names
@@ -641,13 +647,6 @@ _lp_jobcount_color()
     fi
 
     echo -ne "$ret"
-}
-
-
-# Tells if we are running in a terminal multiplexer
-_lp_in_multiplexer()
-{
-    [[ "$TERM" == screen* ]]
 }
 
 
@@ -1375,10 +1374,6 @@ _lp_set_prompt()
     LP_TIME=$(_lp_sr "$(_lp_time)")
 
     # in main prompt: no space
-    if _lp_in_multiplexer ; then
-        LP_MARK_BRACKET_OPEN="${LP_COLOR_IN_MULTIPLEXER}${LP_MARK_BRACKET_OPEN}${NO_COL}"
-        LP_MARK_BRACKET_CLOSE="${LP_COLOR_IN_MULTIPLEXER}${LP_MARK_BRACKET_CLOSE}${NO_COL}"
-    fi
     LP_PROXY="$(_lp_proxy)"
 
     # right of main prompt: space at left


### PR DESCRIPTION
- Fix: `LP_MARK_BRACKET_OPEN` was growing when `liquidprompt` was running inside `screen`.
- Optimization: do terminal multiplexer detection just once at startup: the terminal multiplexer is always a parent process and that can not change during the shell life.
