### PR TITLE
Fixed issue #162.

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -996,6 +996,7 @@ _lp_bzr_branch_color()
     [[ "$LP_ENABLE_BZR" != 1 ]] && return
     local output
     output=$(bzr version-info --check-clean --custom --template='{branch_nick} {revno} {clean}' 2> /dev/null)
+    [[ $? -ne 0 ]] && return
     local tuple=($output)
     local branch=${tuple[0]}
     local revno=${tuple[1]}


### PR DESCRIPTION
Added programm exit value check to `_lp_bzr_branch_color` to return in case the current directory is not a Bazaar directory.

The problem was that the function assumed that every directory would be a valid Bazaar directory. Simply added an exit code check with early return after the _version-info_ call.
