### PR TITLE
The real fix for IFS

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -1381,13 +1381,13 @@ _lp_time()
 
 _lp_set_prompt()
 {
+    # as this get the last returned code, it should be called first
+    LP_ERR="$(_lp_sl $(_lp_return_value $?))"
+
     # Reset IFS to its default value to avoid strange behaviors
     # (in case the user is playing with the value at the prompt)
     local IFS="$(echo -e ' \t')
 "       # space, tab, LF
-
-    # as this get the last returned code, it should be called first
-    LP_ERR="$(_lp_sl $(_lp_return_value $?))"
 
     # execute the old prompt if not on Mac OS X (Mountain) Lion
     case "$LP_OS" in


### PR DESCRIPTION
This reverts the broken patch from #133 (see my comment there about the nasty bug it introduces) and really fixes #132 by resetting `IFS` at the beginning of our shell code, not just for `_lp_load_color`.
