### PR TITLE
fix as root, we only got the LP_MARK_DISABLED

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -1483,8 +1483,11 @@ _lp_set_prompt()
                 fi # svn
             fi # hg
 
-        else # if this vcs rep is disabled
+        # if this vcs rep is disabled
+        elif [[ "$LP_ENABLE_VCS_ROOT" != 1 && "$EUID" == 0 ]]; then
             LP_VCS="" # not necessary, but more readable
+            LP_VCS_TYPE=""
+        else
             LP_VCS_TYPE="disabled"
         fi
 


### PR DESCRIPTION
cf2ff289c8755019bba5dff271ae3d03a784fc5e introduced kind of a bug.

`LP_DISABLED_VCS_PATH` being defined to `/` when we're root, we always got the `LP_MARK_DISABLED`, wherever we were, at the end of the root prompt instead of the classic root mark (which, for me, is `#`).
