### PR TITLE
fix typo in config copying example command

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ To use it everytime you start a shell add the following line to your
 
 Next up is the configuration, you can skip this step if you already like the defaults:
 
-`cp ~/liquidpromp/liquidpromptrc-dist ~/.config/liquidpromptrc`
+`cp ~/liquidprompt/liquidpromptrc-dist ~/.config/liquidpromptrc`
 
 You can also copy the file to `~/.liquidpromptrc`.
 Use your favorite text editor to change the defaults.


### PR DESCRIPTION
"liquidpromp" -> "liquidprompt"
