### PR TITLE
Error when sensors are disabled

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -1,4 +1,3 @@
-
 ################################################################################
 # LIQUID PROMPT
 # An intelligent and non intrusive prompt for bash and zsh
@@ -1195,7 +1194,7 @@ _lp_temp_sensors() {
     # Return the average system temperature we get through the sensors command
     local count=0
     local temperature=0
-    for i in $(sensors | grep -E "^(Core|temp)" |
+    for i in $(sensors | grep -E "^(Core|temp)" | grep -v 'sensor = disabled' |
             sed -r "s/.*: *\+([0-9]*)\..°.*/\1/g"); do
         temperature=$(($temperature+$i))
         count=$(($count+1))


### PR DESCRIPTION
When some temperatur sensors are reported but disabled, they show values of about -128.0°C. This causes problems with the parsing code. This patch ignores disabled sensors. 
