### PR TITLE
Use `command git` instead of `git`

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -689,12 +689,12 @@ _lp_git_branch()
 {
     [[ "$LP_ENABLE_GIT" != 1 ]] && return
     local gitdir
-    gitdir="$([ $(git ls-files . 2>/dev/null | wc -l) -gt 0 ] && git rev-parse --git-dir 2>/dev/null)"
+    gitdir="$([ $(command git ls-files . 2>/dev/null | wc -l) -gt 0 ] && command git rev-parse --git-dir 2>/dev/null)"
     [[ $? -ne 0 || ! $gitdir =~ (.*\/)?\.git.* ]] && return
-    local branch="$(git symbolic-ref HEAD 2>/dev/null)"
+    local branch="$(command git symbolic-ref HEAD 2>/dev/null)"
     if [[ $? -ne 0 || -z "$branch" ]] ; then
         # In detached head state, use commit instead
-        branch="$(git rev-parse --short HEAD 2>/dev/null)"
+        branch="$(command git rev-parse --short HEAD 2>/dev/null)"
     fi
     [[ $? -ne 0 || -z "$branch" ]] && return
     branch="${branch#refs/heads/}"
@@ -716,32 +716,32 @@ _lp_git_branch_color()
     if [[ -n "$branch" ]] ; then
 
         local GD
-        git diff --quiet >/dev/null 2>&1
+        command git diff --quiet >/dev/null 2>&1
         GD=$?
 
         local GDC
-        git diff --cached --quiet >/dev/null 2>&1
+        command git diff --cached --quiet >/dev/null 2>&1
         GDC=$?
 
         local end="$NO_COL"
-        if git status 2>/dev/null | grep -q '\(# Untracked\)'; then
+        if command git status 2>/dev/null | grep -q '\(# Untracked\)'; then
             end="$LP_COLOR_CHANGES$LP_MARK_UNTRACKED$end"
         fi
 
-        if [[ -n "$(git stash list 2>/dev/null)" ]]; then
+        if [[ -n "$(command git stash list 2>/dev/null)" ]]; then
             end="$LP_COLOR_COMMITS$LP_MARK_STASH$end"
         fi
 
         local remote
-        remote="$(git config --get branch.${branch}.remote 2>/dev/null)"
+        remote="$(command git config --get branch.${branch}.remote 2>/dev/null)"
 
         local has_commit
         has_commit=0
         if [[ -n "$remote" ]] ; then
             local remote_branch
-            remote_branch="$(git config --get branch.${branch}.merge)"
+            remote_branch="$(command git config --get branch.${branch}.merge)"
             if [[ -n "$remote_branch" ]] ; then
-                has_commit=$(git rev-list --no-merges --count ${remote_branch/refs\/heads/refs\/remotes\/$remote}..HEAD 2>/dev/null)
+                has_commit=$(command git rev-list --no-merges --count ${remote_branch/refs\/heads/refs\/remotes\/$remote}..HEAD 2>/dev/null)
                 if [[ -z "$has_commit" ]] ; then
                     has_commit=0
                 fi
@@ -749,7 +749,7 @@ _lp_git_branch_color()
         fi
         if [[ "$GD" -eq 1 || "$GDC" -eq "1" ]] ; then
             local has_line
-            has_lines=$(git diff --numstat 2>/dev/null | awk 'NF==3 {plus+=$1; minus+=$2} END {printf("+%d/-%d\n", plus, minus)}')
+            has_lines=$(command git diff --numstat 2>/dev/null | awk 'NF==3 {plus+=$1; minus+=$2} END {printf("+%d/-%d\n", plus, minus)}')
             if [[ "$has_commit" -gt "0" ]] ; then
                 # Changes to commit and commits to push
                 ret="${LP_COLOR_CHANGES}${branch}${NO_COL}(${LP_COLOR_DIFF}$has_lines${NO_COL},${LP_COLOR_COMMITS}$has_commit${NO_COL})${end}"
@@ -1426,7 +1426,7 @@ _lp_set_prompt()
             LP_VCS_TYPE="git"
             if [[ -n "$LP_VCS" ]]; then
                 # If this is a git-svn repository
-                if [[ -d "$(git rev-parse --git-dir 2>/dev/null)/svn" ]]; then
+                if [[ -d "$(command git rev-parse --git-dir 2>/dev/null)/svn" ]]; then
                     LP_VCS_TYPE="git-svn"
                 fi
             fi # git-svn


### PR DESCRIPTION
This is to get past aliases that use hub (which
is too slow for prompts).
