### PR TITLE
Fix issue #124

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -555,6 +555,7 @@ _lp_shorten_path()
             echo "$p"
         fi
     else # zsh
+        unset p
         if (( len > max_len )); then
             print -P "%-${LP_PATH_KEEP}~%${max_len}<${LP_MARK_SHORTEN_PATH}<%~%<<"
         else
@@ -585,6 +586,7 @@ _lp_get_dirtrim() {
         done
         [[ "$((PROMPT_DIRTRIM))" -eq 0 ]] && PROMPT_DIRTRIM=1
     fi
+    unset p
     echo "$PROMPT_DIRTRIM"
 }
 
@@ -1413,7 +1415,7 @@ _lp_set_prompt()
     # right of main prompt: space at left
     LP_VENV=$(_lp_sl "$(_lp_virtualenv)")
     # if change of working directory
-    if [[ "$LP_OLD_PWD" != "$PWD" ]]; then
+    if [[ "$LP_OLD_PWD" != "LP:$PWD" ]]; then
         LP_VCS=""
         LP_VCS_TYPE=""
         # LP_HOST is a global set at load time
@@ -1471,7 +1473,7 @@ _lp_set_prompt()
         else
             LP_PWD="${LP_COLOR_PATH_ROOT}${LP_PWD}${NO_COL}"
         fi
-        LP_OLD_PWD="$PWD"
+        LP_OLD_PWD="LP:$PWD"
 
     # if do not change of working directory but...
     elif [[ -n "$LP_VCS_TYPE" ]]; then # we are still in a VCS dir


### PR DESCRIPTION
unset local variables that interfere with autonamedirs in oh-my-zsh
1) unset local variable p before use in zsh pwd truncation
2) prefix LP_OLD_PWD with "LP:" to avoid autonaming
