### PR TITLE
Avoid spilling error messages when temp. sensors are unavailable

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -1195,12 +1195,16 @@ _lp_temp_sensors() {
     # Return the average system temperature we get through the sensors command
     local count=0
     local temperature=0
-    for i in $(sensors | grep -E "^(Core|temp)" |
+    for i in $(sensors 2> /dev/null | grep -E "^(Core|temp)" |
             sed -r "s/.*: *\+([0-9]*)\..°.*/\1/g"); do
         temperature=$(($temperature+$i))
         count=$(($count+1))
     done
-    echo -ne "$(($temperature/$count))"
+    if [ $count -eq 0 ]; then
+        echo -ne "0"
+    else
+        echo -ne "$(($temperature/$count))"
+    fi
 }
 
 # Will set _lp_temp_function so the temperature monitoring feature use an


### PR DESCRIPTION
The `sensors` command prints out error messages if there are no actual
sensors available. Seeing them at every prompt is not good UX. It also
caused a division by 0 due to assuming the sensor count is always >= 1.
Fix both issues by redirecting stderr to /dev/null and checking for a
sensor count of 0.
