### PR TITLE
Skip N/A sensor values

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -1195,7 +1195,7 @@ _lp_temp_sensors() {
     # Return the average system temperature we get through the sensors command
     local count=0
     local temperature=0
-    for i in $(sensors | grep -E "^(Core|temp)" |
+    for i in $(sensors | grep -E "^(Core|temp).*C" |
             sed -r "s/.*: *\+([0-9]*)\..°.*/\1/g"); do
         temperature=$(($temperature+$i))
         count=$(($count+1))


### PR DESCRIPTION
By default, sensor values that don't return valid values are still considered. This causes errors on the following arithmetic calculations, so this commit fixes it.

Compare this output:

```
sensors |grep -E "^(Core|temp)"     
temp1:        +44.0°C  (crit = +127.0°C)  
temp2:        +34.0°C  (crit = +100.0°C)
Core 0:       +35.0°C  (high = +105.0°C, crit = +105.0°C)
Core 1:       +34.0°C  (high = +105.0°C, crit = +105.0°C)
temp1:        +44.0°C  
temp2:            N/A  
temp3:            N/A  
temp4:            N/A  
temp5:        +30.0°C  
temp6:            N/A  
temp7:        +28.0°C  
temp8:            N/A  
temp9:        +28.0°C  
temp10:       +36.0°C  
temp11:       +37.0°C  
temp12:           N/A  
temp13:           N/A  
temp14:           N/A  
temp15:           N/A  
temp16:           N/A  
```

This pull request changes this to:

```
temp1:        +45.0°C  (crit = +127.0°C)
temp2:        +36.0°C  (crit = +100.0°C)
Core 0:       +35.0°C  (high = +105.0°C, crit = +105.0°C)
Core 1:       +37.0°C  (high = +105.0°C, crit = +105.0°C)
temp1:        +45.0°C  
temp5:        +30.0°C  
temp7:        +28.0°C  
temp9:        +29.0°C  
temp10:       +36.0°C   
temp11:       +37.0°C 
```
