### PR TITLE
fix promblematic shorten path function

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -524,7 +524,7 @@ _lp_shorten_path()
         ret="${p}"
     elif [[ ${LP_PATH_KEEP} == 0 ]]; then
         # len is over max len, show as much of the tail as is allowed
-        local ret="${p##*/}" # show at least complete current directory
+        ret="${p##*/}" # show at least complete current directory
         p="${p:0:${#p} - ${#ret}}"
         ret="${mask}${p:${#p} - (${max_len} - ${#ret} - ${#mask})}${ret}"
     else


### PR DESCRIPTION
I have a few problems with the current implementation of the shorten path function of liquidprompt:
- It does not produce the same results for bash and zsh.
- It does not respect the maximum length.
- For specific cases inserts the elipsis when it only lengths the path and does nothing to shorten it.
- For specific cases repeates part of the path.

The most egregious example I could find which covers the above points:

```
echo $((${COLUMNS:-80}*$LP_PATH_LENGTH/100))
30
```

This is how the maximum length is calculated and which is used by the function.
In the examples the 'shortened' path uses 39 characters in bash and 41 in zsh.

bash:

```
1d [rolf:~/workspace/ … /arduino/abc_temperature] develop* ± pwd
/home/rolf/workspace/arduino/abc_temperature
1d [rolf:~/workspace/ … /abc_temperature/src] develop* ± pwd
/home/rolf/workspace/arduino/abc_temperature/src
```

zsh:

```
1d [rolf:~/workspace … ace/arduino/abc_temperature] develop* ± pwd
/home/rolf/workspace/arduino/abc_temperature
1d [rolf:~/workspace … arduino/abc_temperature/src] develop* ± pwd
/home/rolf/workspace/arduino/abc_temperature/src
```

This new implementation is portable across bash and zsh.
It respects maximum length strictly and only exceeds it when it has to
respect LP_PATH_KEEP leading dirs and/or current directory name length.
It adds support for only showing the current directory, without leading
ones. This fixes Issue #219.
Just like the previous implementation it uses only shell functionality
and makes no calls to executables.
