### PR TITLE
Fix use of non-exist variable 'count'

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -1393,7 +1393,7 @@ _lp_temp_sensors() {
             temperature=$i
         fi
     done
-    echo -ne "$(($temperature/$count))"
+    echo -ne "$temperature"
 }
 
 # Will set _LP_TEMP_FUNCTION so the temperature monitoring feature use an


### PR DESCRIPTION
Fixes shell error:
""bash: 46 / : syntax error: operand expected (error token is "/ ")
