### PR TITLE
Support for counting screen sessions running with extra parameters

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -665,7 +665,7 @@ _lp_jobcount_color()
 
     local running=$(( $(jobs -r | wc -l) ))
     local stopped=$(( $(jobs -s | wc -l) ))
-    local n_screen=$(screen -ls 2> /dev/null | grep -c Detach)
+    local n_screen=$(screen -ls 2> /dev/null | grep -c '[Dd]etach[^)]*)$')
     local n_tmux=$(tmux list-sessions 2> /dev/null | grep -cv attached)
     local detached=$(( $n_screen + $n_tmux ))
     local m_detached="d"


### PR DESCRIPTION
In some cases (multi user enabled in screen for example), the count of
detached screen sessions was incorrect. The command to locate these has
been improved using a more tolerant regex, which also makes sure the
"Detached" word appears inside a parenthesis (so it's not an attached
screen to a machine called Detach for example). 
