### PR TITLE
Put the old behavior back into git lines count

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -768,16 +768,32 @@ _lp_git_branch_color()
             fi
         fi
 
-        local shortstat
         local ret
+        local shortstat # only to check for uncommitted changes
         shortstat="$(LC_ALL=C \git diff --shortstat HEAD 2>/dev/null)"
+
         if [[ -n "$shortstat" ]] ; then
+            local u_stat # shorstat of *unstaged* changes
+            u_stat="$(LC_ALL=C \git diff --shortstat 2>/dev/null)"
+            u_stat=${u_stat/*changed, /} # removing "n file(s) changed"
+
+            local i_lines # inserted lines
+            if [[ "$u_stat" = *insertion* ]] ; then
+                i_lines=${u_stat/ inser*}
+            else
+                i_lines=0
+            fi
+
+            local d_lines # deleted lines
+            if [[ "$u_stat" = *deletion* ]] ; then
+                d_lines=${u_stat/*\(+\), }
+                d_lines=${d_lines/ del*/}
+            else
+                d_lines=0
+            fi
+
             local has_lines
-            #has_lines=$(\git diff --numstat 2>/dev/null | awk 'NF==3 {plus+=$1; minus+=$2} END {printf("+%d/-%d\n", plus, minus)}')
-            has_lines=${shortstat/*changed, /}
-            has_lines=${has_lines/ inser*, /\/-}
-            has_lines=${has_lines/ del*/}
-            [[ "$shortstat" = *insertion* ]] && has_lines="+${has_lines/ inser*/}" || has_lines="-$has_lines"
+            has_lines="+$i_lines/-$d_lines"
 
             if [[ "$has_commit" -gt "0" ]] ; then
                 # Changes to commit and commits to push


### PR DESCRIPTION
Prior to some (recent) changes in the git status information in the liquidprompt (see da940677ee and 0c1e66d12a), we had the following behavior:
- the line count, e.g. (+2,-1) was a mere summary of a `git diff`. Here is it very important to understand that staged changes do _not_ appear here by default, you have to perform `git diff HEAD` or `git diff --staged` to see them
- the branch color was
  - red if there were uncommitted changes (even in the staging area)
  - yellow if some commits are not pushed, and if we were not in the previous case
  - green otherwise

With da940677ee, we use `git diff --shortstat HEAD` to compute the line count, which gives different results if some changes have been _staged_. I see two drawbacks of this approach:
- it reduces the amount of information available, since the staging area is ignored (the same line count will appear if some changes are staged or not).
- users of `git diff` may be confused about this line count, since this it is not the "usual" meaning of `git diff`.

With the old behavior, I got used to the fact that a line count of (+0,-0) meant that all changes were staged for example, but since the branch was red, the changes were not committed.

The `git diff --shorstat HEAD` is still a valid way to detect uncommitted changes, but we have to perform another git command to have a line count with the old behavior.
