### PR TITLE
fix bash syntax error in Darwin kernel-detection code, and add version for Mavericks

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -1606,8 +1606,8 @@ _lp_set_prompt()
     case "$LP_OS" in
         Linux|FreeBSD|OpenBSD|SunOS) $LP_OLD_PROMPT_COMMAND ;;
         Darwin)
-            case "$(LP_DWIN_KERNEL_REL_VER)" in
-                11|12) update_terminal_cwd ;;
+            case "${LP_DWIN_KERNEL_REL_VER}" in
+                11|12|13) update_terminal_cwd ;;
                 *) $LP_OLD_PROMPT_COMMAND ;;
             esac ;;
     esac


### PR DESCRIPTION
Sorry for the bad pull request... this one is better.
