### PR TITLE
Don't override PROMPT_DIRTRIM when path shortening is disabled

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -604,7 +604,7 @@ _lp_shorten_path()
 # liquidprompt can calculate this number under two condition, path shortening
 # must be activated and PROMPT_DIRTRIM must be already set.
 _lp_get_dirtrim() {
-    [[ "$LP_ENABLE_SHORTEN_PATH" != 1 ]] && echo 0 && return
+    [[ "$LP_ENABLE_SHORTEN_PATH" != 1 ]] && echo $PROMPT_DIRTRIM && return
 
     local p="${PWD/$HOME/~}"
     local len=${#p}


### PR DESCRIPTION
While testing for an advice I gave on issue #219, I realized that liquidprompt will override `PROMPT_DIRTRIM` settings even if we ask it not to modify the displayed path with `LP_ENABLE_SHORTEN_PATH=0`.

That's a minor issue but the fix is simple.
