### PR TITLE
Add LP_PATH_DEFAULT to implement #219

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -67,6 +67,7 @@ if test -n "$BASH_VERSION" -a -n "$PS1" -a -n "$TERM" ; then
     _LP_TIME_SYMBOL="\t"
     _LP_MARK_SYMBOL='\$'
     _LP_FIRST_INDEX=0
+    LP_PATH_DEFAULT="\\w"
 elif test -n "$ZSH_VERSION" ; then
     _LP_SHELL_bash=false
     _LP_SHELL_zsh=true
@@ -77,6 +78,7 @@ elif test -n "$ZSH_VERSION" ; then
     _LP_TIME_SYMBOL="%*"
     _LP_MARK_SYMBOL='%(!.#.%%)'
     _LP_FIRST_INDEX=1
+    LP_PATH_DEFAULT="%~"
 else
     echo "liquidprompt: shell not supported" >&2
     return
@@ -220,6 +222,7 @@ _lp_source_config()
     LP_TITLE_CLOSE=${LP_TITLE_CLOSE:-"\a"}
     LP_SCREEN_TITLE_OPEN=${LP_SCREEN_TITLE_OPEN:-"\033k"}
     LP_SCREEN_TITLE_CLOSE=${LP_SCREEN_TITLE_CLOSE:-"\033\134"}
+    LP_PATH_DEFAULT=${LP_PATH_DEFAULT:-$LP_PATH_DEFAULT}
 
     LP_ENABLE_PERM=${LP_ENABLE_PERM:-1}
     LP_ENABLE_SHORTEN_PATH=${LP_ENABLE_SHORTEN_PATH:-1}
@@ -510,12 +513,11 @@ unset _lp_connection
 # + keep some left part of the path if asked
 _lp_shorten_path()
 {
+
     if [[ "$LP_ENABLE_SHORTEN_PATH" != 1 ]] ; then
+        LP_PWD="$LP_PATH_DEFAULT"
         if $_LP_SHELL_bash; then
             [[ -n "$PROMPT_DIRTRIM" ]] && _lp_set_dirtrim
-            LP_PWD="\\w"
-        else
-            LP_PWD='%~'
         fi
         return
     fi


### PR DESCRIPTION
Even if we don't want `_lp_shorten_path` not to handle path, we may want it not to override our default configuration for the path display.

See #219.
