### PR TITLE
Feature: show full hostname

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -24,26 +24,26 @@
 # AUTHORS #
 ###########
 
-# Alex Prengère     <alexprengere@gmail.com>      # untracked git files
-# Anthony Gelibert  <anthony.gelibert@me.com>     # small code fix
+# Alex Prengère     <alexprengere@gmail.com>      # Untracked git files
+# Anthony Gelibert  <anthony.gelibert@me.com>     # Several fix
 # Aurelien Requiem  <aurelien@requiem.fr>         # Major clean refactoring, variable path length, error codes, several bugfixes.
-# Brendan Fahy      <bmfahy@gmail.com>            # postfix variable
+# Brendan Fahy      <bmfahy@gmail.com>            # Postfix variable
 # Clément Mathieu   <clement@unportant.info>      # Bazaar support
-# David Loureiro    <david.loureiro@sysfera.com>  # small portability fix
+# David Loureiro    <david.loureiro@sysfera.com>  # Small portability fix
 # Étienne Deparis   <etienne@depar.is>            # Fossil support
 # Florian Le Frioux <florian@lefrioux.fr>         # Use ± mark when root in VCS dir.
-# François Schmidts <francois.schmidts@gmail.com> # small code fix, _lp_get_dirtrim
+# François Schmidts <francois.schmidts@gmail.com> # Small code fix, _lp_get_dirtrim
 # Frédéric Lepied   <flepied@gmail.com>           # Python virtual env
 # Jonas Bengtsson   <jonas.b@gmail.com>           # Git remotes fix
 # Joris Dedieu      <joris@pontiac3.nfrance.com>  # Portability framework, FreeBSD support, bugfixes.
-# Joris Vaillant    <joris.vaillant@gmail.com>    # small git fix
-# Luc Didry         <luc@fiat-tux.fr>             # Zsh port, several fix
+# Joris Vaillant    <joris.vaillant@gmail.com>    # Small git fix
+# Luc Didry         <luc@fiat-tux.fr>             # ZSH port, several fix
 # Ludovic Rousseau  <ludovic.rousseau@gmail.com>  # Lot of bugfixes.
 # Markus Dreseler   <github@dreseler.de>          # Runtime of last command
-# Nicolas Lacourte  <nicolas@dotinfra.fr>         # screen title
+# Nicolas Lacourte  <nicolas@dotinfra.fr>         # Screen title
 # nojhan            <nojhan@gmail.com>            # Main author.
 # Olivier Mengué    <dolmen@cpan.org>             # Major optimizations and refactorings everywhere.
-# Poil              <poil@quake.fr>               # speed improvements
+# Poil              <poil@quake.fr>               # Speed improvements
 # Thomas Debesse    <thomas.debesse@gmail.com>    # Fix columns use.
 # Yann 'Ze' Richard <ze@nbox.org>                 # Do not fail on missing commands.
 

--- a/liquidprompt
+++ b/liquidprompt
@@ -41,8 +41,8 @@
 # Ludovic Rousseau  <ludovic.rousseau@gmail.com>  # Lot of bugfixes.
 # Markus Dreseler   <github@dreseler.de>          # Runtime of last command
 # Nicolas Lacourte  <nicolas@dotinfra.fr>         # Screen title
-# nojhan            <nojhan@gmail.com>            # Main author.
-# Olivier Mengué    <dolmen@cpan.org>             # Major optimizations, refactorings everywhere; Co-maintainer
+# nojhan            <nojhan@gmail.com>            # Original author.
+# Olivier Mengué    <dolmen@cpan.org>             # Major optimizations, refactorings everywhere; current maintainer
 # Poil              <poil@quake.fr>               # Speed improvements
 # Thomas Debesse    <thomas.debesse@gmail.com>    # Fix columns use.
 # Yann 'Ze' Richard <ze@nbox.org>                 # Do not fail on missing commands.

--- a/liquidprompt
+++ b/liquidprompt
@@ -355,6 +355,7 @@ unset _lp_source_config
 [[ "$LP_ENABLE_FOSSIL"  = 1 ]] && { command -v fossil  >/dev/null || LP_ENABLE_FOSSIL=0  ; }
 [[ "$LP_ENABLE_HG"   = 1 ]] && { command -v hg   >/dev/null || LP_ENABLE_HG=0   ; }
 [[ "$LP_ENABLE_BZR"  = 1 ]] && { command -v bzr > /dev/null || LP_ENABLE_BZR=0  ; }
+[[ "$LP_DOMAIN"  = 1 ]] && { command -v hostname > /dev/null || LP_DOMAIN=0  ; }
 case "$LP_OS" in
     Darwin) [[ "$LP_ENABLE_BATT" = 1 ]] && { command -v pmset >/dev/null || LP_ENABLE_BATT=0 ; };;
     *)      [[ "$LP_ENABLE_BATT" = 1 ]] && { command -v acpi >/dev/null || LP_ENABLE_BATT=0 ; };;
@@ -404,6 +405,10 @@ _lp_escape()
     printf "%q" "$*"
 }
 
+# Show always domain in prompt if LP_DOMAIN is set to 1
+# For Bash using the \H to show also the domain does not work consistently
+# across all platforms, hostname -f does and it also works for ZSH
+ [[ "$LP_DOMAIN" = 1 ]] && { _LP_HOST_SYMBOL="$(_lp_escape $(hostname -f) )" ; }
 
 ###############
 # Who are we? #

--- a/liquidprompt
+++ b/liquidprompt
@@ -42,7 +42,7 @@
 # Markus Dreseler   <github@dreseler.de>          # Runtime of last command
 # Nicolas Lacourte  <nicolas@dotinfra.fr>         # Screen title
 # nojhan            <nojhan@gmail.com>            # Main author.
-# Olivier Mengué    <dolmen@cpan.org>             # Major optimizations and refactorings everywhere.
+# Olivier Mengué    <dolmen@cpan.org>             # Major optimizations, refactorings everywhere; Co-maintainer
 # Poil              <poil@quake.fr>               # Speed improvements
 # Thomas Debesse    <thomas.debesse@gmail.com>    # Fix columns use.
 # Yann 'Ze' Richard <ze@nbox.org>                 # Do not fail on missing commands.

--- a/liquidpromptrc-dist
+++ b/liquidpromptrc-dist
@@ -37,6 +37,11 @@ LP_PATH_KEEP=2
 # set to 1 if you want to always see the hostname
 LP_HOSTNAME_ALWAYS=0
 
+# Do you want to show the domain with the hostname
+# Defaults to 0 (do not display domain)
+# set to 1 if you want to set hostname  in the form hostname.domain
+LP_DOMAIN=0
+
 # Do you want to display the user, even if he is the same than the logged one?
 # Defaults to 1 (always display the user)
 # set to 0 if you want to hide the logged user (it will always display different users)

--- a/test.sh
+++ b/test.sh
@@ -130,6 +130,15 @@ git()
     esac
 }
 
+hostname()
+{
+    echo "Fake hostname $@" 1>&2
+    case $1 in
+	"-f" )
+	    echo "hostname.domain";;
+    esac
+}
+
 # global variables
 export http_proxy="fake"
 
@@ -186,8 +195,16 @@ assert_has Load_Level       32%    $LINENO
 assert_has User             "[\\\u"    $LINENO
 if [[ $LP_HOSTNAME_ALWAYS == 0 ]] ; then
     assert_not Hostname     "\\\h"    $LINENO
+    # only show domain if hostname is shown
+    assert_not Domainname     ".domain"    $LINENO
 else
-    assert_has Hostname     "\\\h"    $LINENO
+    if [[ $LP_DOMAIN == 1 ]] ; then
+        assert_has Hostname     "hostname."    $LINENO
+        assert_has Domainname   ".domain"    $LINENO
+    else
+	assert_has Hostname     "\\\h"    $LINENO
+        assert_not Domainname   ".domain"    $LINENO
+    fi
 fi
 assert_has Perms            :    $LINENO
 assert_has Path             $(pwd | sed -e "s|$HOME|~|")    $LINENO
@@ -305,13 +322,21 @@ echo "LOCAL HOST NAME"
 _lp_set_prompt
 log_prompt
 # As the hostname is set once at the script start,
-# and not re-interpret at each prompt,
+# and not re-interpret at each prompt,
 # we cannot export the option in the test script.
 # We thus rely on the existing config.
 if [[ $LP_HOSTNAME_ALWAYS == 0 ]] ; then
     assert_not Hostname     "\\\h"    $LINENO
+    # only show domain if hostname is shown
+    assert_not Domainname     ".domain"    $LINENO
 else
-    assert_has Hostname     "\\\h"    $LINENO
+    if [[ $LP_DOMAIN == 1 ]] ; then
+	assert_has Hostname     "hostname."    $LINENO
+        assert_has Domainname   ".domain"    $LINENO
+    else
+	assert_has Hostname     "\\\h"    $LINENO
+        assert_not Domainname   ".domain"    $LINENO
+    fi
 fi
 
 echo "prompt_OFF"


### PR DESCRIPTION
Added possibility to show domain if host name is shown.

I've added the option LP_DOMAIN to show the domain if the host name is shown.
I also edited the test.sh file to test for new feature.

I'm using the command ```hostname -f``` instead of the ```\H``` (for bash) and ```%M```(for zsh)
because I noticed that the ```\H``` is bash is not the same in all systems (zsh is coherent):

In macos (bash 3.2.48(1)-release) and freeBSD(bash 4.2.45(0)-release) :
```
# hostname -f
host.domain
# export PS1=" \\\h=\h \\\H=\H #"
 \h=host \H=host.domain #
```
In linux: SLC6 (bash: 4.1.2(1)-release), debian(bash:4.2.37(1)-release ) and ubunto(bash: 4.2.25(1)-release) ):

```
# hostname -f
host.domain
# export PS1=" \\\h=\h \\\H=\H #"
 \h=host \H=host #
```

