### PR TITLE
shorten_path: Escape '%' instead of using a var

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -586,9 +586,7 @@ _lp_shorten_path()
     if $_LP_SHELL_bash; then
         LP_PWD="${ret//\\/\\\\}"
     else # zsh
-        #LP_PWD="${ret//%/%%}"  # This doesn't work :(  zsh bug?
-        p='%'
-        LP_PWD="${ret//$p/%%}"
+        LP_PWD="${ret//\%/%%}"
     fi
 }
 


### PR DESCRIPTION
When ${var//orig/replace} is intended with orig as '%' there is no need
to use a variable to avoid the '//%' form if the '%' is escaped.
