### PR TITLE
SVN fix

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -877,7 +877,7 @@ _lp_svn_branch()
     if [[ "$url" == */trunk* ]] ; then
         echo -n trunk
     else
-        _lp_escape "$(expr "$url" : '.*/branches/\([^/]*\)' || expr "$url" : '/\([^/]*\)' || basename "$root")"
+        _lp_escape $(expr "$url" : '.*/branches/\([^/]*\)' || expr "$url" : '/\([^/]*\)' || basename "$root")
     fi
 }
 


### PR DESCRIPTION
This pull request contains two commits :
- The first one renames a misnamed local variable in _lp_svn_branch_color (not really important fix).
- The second one removes useless quotes in the _lp_escape of _lp_svn_branch. Normally, it fixes the bug identified on SVN prompts. I tested it on http://www.andre-simon.de/doku/highlight/en/sfnet.php.
