### PR TITLE
Correct battery processing

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -1144,7 +1144,7 @@ case "$LP_OS" in
     _lp_battery()
     {
         [[ "$LP_ENABLE_BATT" != 1 ]] && return 4
-        local pmset="$(pmset -g batt | tail -n1)"
+        local pmset="$(pmset -g batt | sed -n -e '/InternalBattery/p')"
         local bat="$(cut -f2 <<<"$pmset")"
         bat="${bat%%%*}"
         case "$pmset" in


### PR DESCRIPTION
This pull request contains two commits :
- The first one changes the returned value when "$LP_ENABLE_BATT != 1", in order to respect the API. The behavior was changed when the implementation of "_lp_battery" changed.
- The second one replaces the "pmset -g batt" parsing in Mac OS X. The current one breaks when there is no more battery because there is a warning line displayed before the searched value.  
