### PR TITLE
fixing the untracked flag being always up

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -710,7 +710,7 @@ _lp_git_branch_color()
 
         local end
         end="$NO_COL"
-        if LC_ALL=C \git status -s 2>/dev/null | grep -Eq '^\?\?'; then
+        if LC_ALL=C \git status --porcelain 2>/dev/null | grep -Eq '^\?\?'; then
             end="$LP_COLOR_CHANGES$LP_MARK_UNTRACKED$end"
         fi
 


### PR DESCRIPTION
Merge of b5830cdf2849c75947142753808d10f670ff78fd appears to have created a bug where the untracked flag for the git repository is always up. This fix correct that behavior. 
