### PR TITLE
Improve performance of fossil support

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -962,7 +962,7 @@ _lp_fossil_branch_color()
         fi
 
         if [ "$C2A" -gt 0 ]; then
-            C2A="$LP_MARK_UNTRACKED"
+            C2A="$LP_COLOR_CHANGES$LP_MARK_UNTRACKED"
         else
             C2A=""
         fi


### PR DESCRIPTION
Replace over use of grep/cut with sed or awk, globally reduce number of fossil call. This PR is an answer to issue #188.
