### PR TITLE
.bashrc doesn't work on Mac, tell users to use .profile instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ source liquidprompt/liquidprompt
 ```
 
 To use it every time you start a shell add the following line to your
-`.bashrc` (if you use bash) or `.zshrc` (if you use zsh) or `.profile` (on Mac OS X, since Mac OS's Terminal does not check `.bashrc` on launch:
+`.bashrc` (if you use bash) or `.zshrc` (if you use zsh) or `.profile` (on Mac OS X, since Mac OS's Terminal does not check `.bashrc` on launch):
 
 `source ~/liquidprompt/liquidprompt`
 


### PR DESCRIPTION
Mac OS X terminal doesn't check .bashrc by default on launch, so instruct users to use .profile instead. (FYI, OS X also checks `/etc/profile`, `.bash_profile`, and `.bash_login`).

See https://apple.stackexchange.com/questions/12993/why-doesnt-bashrc-run-automatically
