### PR TITLE
Adding option to use FQDN instead of short hostname

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -67,6 +67,7 @@ if test -n "$BASH_VERSION" -a -n "$PS1" ; then
     _LP_CLOSE_ESC="\]"
     _LP_USER_SYMBOL="\u"
     _LP_HOST_SYMBOL="\h"
+    _LP_FQDN_SYMBOL="\H"
     _LP_TIME_SYMBOL="\t"
     _LP_MARK_SYMBOL='\$'
     _LP_FIRST_INDEX=0
@@ -78,6 +79,7 @@ elif test -n "$ZSH_VERSION" ; then
     _LP_CLOSE_ESC="%}"
     _LP_USER_SYMBOL="%n"
     _LP_HOST_SYMBOL="%m"
+    _LP_FQDN_SYMBOL="\M"
     _LP_TIME_SYMBOL="%*"
     _LP_MARK_SYMBOL='%(!.#.%%)'
     _LP_FIRST_INDEX=1
@@ -255,6 +257,7 @@ _lp_source_config()
     LP_ENABLE_TITLE=${LP_ENABLE_TITLE:-0}
     LP_ENABLE_SCREEN_TITLE=${LP_ENABLE_SCREEN_TITLE:-0}
     LP_ENABLE_SSH_COLORS=${LP_ENABLE_SSH_COLORS:-0}
+    LP_ENABLE_FQDN=${LP_ENABLE_FQDN:-0}
     # LP_DISABLED_VCS_PATH="${LP_DISABLED_VCS_PATH}"
 
     # LP_MARK_DEFAULT="$LP_MARK_DEFAULT"
@@ -471,6 +474,13 @@ _chroot()
 LP_HOST="$(_chroot)"
 unset _chroot
 
+# Which host symbol should we use?
+if [[ "${LP_ENABLE_FQDN}" -eq "1" ]] ; then
+    LP_HOST_SYMBOL="${_LP_FQDN_SYMBOL}"
+else
+    LP_HOST_SYMBOL="${_LP_HOST_SYMBOL}"
+fi
+
 # If we are connected with a X11 support
 if [[ -n "$DISPLAY" ]] ; then
     LP_HOST="${LP_COLOR_X11_ON}${LP_HOST}@${NO_COL}"
@@ -484,7 +494,7 @@ lcl)
         # FIXME do we want to display the chroot if local?
         LP_HOST="" # no hostname if local
     else
-        LP_HOST="${LP_HOST}${LP_COLOR_HOST}${_LP_HOST_SYMBOL}${NO_COL}"
+        LP_HOST="${LP_HOST}${LP_COLOR_HOST}${LP_HOST_SYMBOL}${NO_COL}"
     fi
     ;;
 ssh)
@@ -495,22 +505,22 @@ ssh)
         # FIXME check portability of cksum and add more formats (bold? 256 colors?)
         hash=$(( 1 + $(hostname | cksum | cut -d " " -f 1) % 6 ))
         color=${_LP_OPEN_ESC}$(ti_setaf $hash)${_LP_CLOSE_ESC}
-        LP_HOST="${LP_HOST}${color}${_LP_HOST_SYMBOL}${NO_COL}"
+        LP_HOST="${LP_HOST}${color}${LP_HOST_SYMBOL}${NO_COL}"
         unset hash
         unset color
     else
         # the same color for all hosts
-        LP_HOST="${LP_HOST}${LP_COLOR_SSH}${_LP_HOST_SYMBOL}${NO_COL}"
+        LP_HOST="${LP_HOST}${LP_COLOR_SSH}${LP_HOST_SYMBOL}${NO_COL}"
     fi
     ;;
 su)
-    LP_HOST="${LP_HOST}${LP_COLOR_SU}${_LP_HOST_SYMBOL}${NO_COL}"
+    LP_HOST="${LP_HOST}${LP_COLOR_SU}${LP_HOST_SYMBOL}${NO_COL}"
     ;;
 tel)
-    LP_HOST="${LP_HOST}${LP_COLOR_TELNET}${_LP_HOST_SYMBOL}${NO_COL}"
+    LP_HOST="${LP_HOST}${LP_COLOR_TELNET}${LP_HOST_SYMBOL}${NO_COL}"
     ;;
 *)
-    LP_HOST="${LP_HOST}${_LP_HOST_SYMBOL}" # defaults to no color
+    LP_HOST="${LP_HOST}${LP_HOST_SYMBOL}" # defaults to no color
     ;;
 esac
 

--- a/liquidpromptrc-dist
+++ b/liquidpromptrc-dist
@@ -139,4 +139,7 @@ LP_ENABLE_SSH_COLORS=0
 # will be disabled
 LP_DISABLED_VCS_PATH=""
 
+# Use the FQDN instead of the short hostname if the hostname is displayed
+LP_ENABLE_FQDN=0
+
 # vim: set et sts=4 sw=4 tw=120 ft=sh:


### PR DESCRIPTION
This pull request adds an option (LP_ENABLE_FQDN) which will set whether or not the full hostname is used. This leverages the prompt's hostname option (%H for bash and %M for ZSH).

There are some reports that the output of these values may be incorrect on some systems / with some shell versions.  I do not account for that in this change.