### PR TITLE
Fix incorrect detection of tmux output if tmux is not installed

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -641,7 +641,7 @@ _lp_jobcount_color()
     local running=$(( $(jobs -r | wc -l) ))
     local stopped=$(( $(jobs -s | wc -l) ))
     local n_screen=$(screen -ls 2> /dev/null | grep -c '[Dd]etach[^)]*)$')
-    local n_tmux=$(tmux list-sessions 2> /dev/null | grep -cv attached)
+    local n_tmux=$(tmux list-sessions 2> /dev/null | grep -cvE 'attached|command not found')
     local detached=$(( $n_screen + $n_tmux ))
     local m_detached="d"
     local m_stop="z"


### PR DESCRIPTION
If tmux is not installed then it always detects 1 detached job.
