### PR TITLE
add support for SVN paths that are not branches or trunk (ie tags) and a...

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -877,8 +877,12 @@ _lp_svn_branch()
     url="${url:${#root}}"
     if [[ "$url" == */trunk* ]] ; then
         echo -n trunk
-    else
+    elif [[ "$url" == */branches* ]] ; then
         _lp_escape "$(expr "$url" : '.*/branches/\([^/]*\)' || expr "$url" : '/\([^/]*\)' || basename "$root")"
+    elif [[ "$url" == */tags* ]] ; then
+        _lp_escape "$(expr "$url" : '.*/tags/\([^/]*\)' || expr "$url" : '/\([^/]*\)' || basename "$root")"
+    else
+        _lp_escape "$(basename "$root")"
     fi
 }
 


### PR DESCRIPTION
...lso fallback to displaying the repo's root name in the case where the repo path is none of tags/branches/trunk
This is a fix for issue 292
