### PR TITLE
Enable support for Software Collections

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -261,6 +261,7 @@ _lp_source_config()
         LP_ENABLE_RUNTIME=${LP_ENABLE_RUNTIME:-0}
     fi
     LP_ENABLE_VIRTUALENV=${LP_ENABLE_VIRTUALENV:-1}
+    LP_ENABLE_SCLS=${LP_ENABLE_SCLS:-1}
     LP_ENABLE_VCS_ROOT=${LP_ENABLE_VCS_ROOT:-0}
     LP_ENABLE_TITLE=${LP_ENABLE_TITLE:-0}
     LP_ENABLE_SCREEN_TITLE=${LP_ENABLE_SCREEN_TITLE:-0}
@@ -1547,6 +1548,13 @@ _lp_set_prompt()
         LP_VENV=
     fi
 
+    # Display the current software collections enabled, if available
+    if [[ "$LP_ENABLE_SCLS,$X_SCLS" = 1,?* ]] ; then
+        LP_SCLS=" [${LP_COLOR_VIRTUALENV}${X_SCLS%"${X_SCLS##*[![:space:]]}"}${NO_COL}]"
+    else
+        LP_SCLS=
+    fi
+
     LP_RUNTIME=$(_lp_sl "$(_lp_runtime)")
 
     # if change of working directory
@@ -1646,7 +1654,7 @@ _lp_set_prompt()
         # add user, host and permissions colon
         PS1="${PS1}${LP_BRACKET_OPEN}${LP_USER}${LP_HOST}${LP_PERM}"
 
-        PS1="${PS1}${LP_PWD}${LP_BRACKET_CLOSE}${LP_VENV}${LP_PROXY}"
+        PS1="${PS1}${LP_PWD}${LP_BRACKET_CLOSE}${LP_SCLS}${LP_VENV}${LP_PROXY}"
 
         # Add VCS infos
         # If root, the info has not been collected unless LP_ENABLE_VCS_ROOT

--- a/liquidpromptrc-dist
+++ b/liquidpromptrc-dist
@@ -111,6 +111,10 @@ LP_RUNTIME_THRESHOLD=2
 # Recommended value is 1
 LP_ENABLE_VIRTUALENV=1
 
+# Display the enabled software collections, if any
+# Recommended value is 1
+LP_ENABLE_SCLS=1
+
 # Show average system temperature
 LP_ENABLE_TEMP=1
 


### PR DESCRIPTION
Fedora, RHEL, and CentOS have support for parallel installations of versions of software components such as python, perl, mariadb, etc. One of the common ways to enable the use of a particular collection is to execute a bash shell from the invocation line. That invocation looks like:

```
scl enable python27 mariadb55 bash
```

The software collection then sets an environment variable that is a white space separated list of all enabled collections

```
X_SCLS=python27 mariadb55 
```

An example of an enabled software collection in a python virtualenv in a git repo:

```
[nzwulfin:~/oso/srtracker] [python27 mariadb55] [flask] master(+4/-1)* ± 
```

The [software collections website](https://www.softwarecollections.org/en/) has more information about the implementation of the software.
