### PR TITLE
Fixes Bazaar support for zsh

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -1052,7 +1052,10 @@ _lp_bzr_branch_color()
     local output
     output="$(bzr version-info --check-clean --custom --template='{branch_nick} {revno} {clean}' 2> /dev/null)"
     [[ $? -ne 0 ]] && return
-    local tuple=($output)
+    $_LP_SHELL_zsh && setopt local_options && setopt sh_word_split
+    local tuple
+    tuple=($output)
+    $_LP_SHELL_zsh && unsetopt sh_word_split
     local branch=${tuple[_LP_FIRST_INDEX+0]}
     local revno=${tuple[_LP_FIRST_INDEX+1]}
     local clean=${tuple[_LP_FIRST_INDEX+2]}


### PR DESCRIPTION
This fixes issue #301.

Local arrays are not directly supported in zsh, so `local tuple` is declared and initialized on two separate lines.

Unlike bash, words separated by a space are not split into arrays in zsh. If zsh is the shell, the function local options are set to support `sh_word_split`, which supports bash-like splitting. By using function local options the user's setting for sh_word_split is unaffected.
