### PR TITLE
Handle neagative temperature in _lp_acpi_temp

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -1380,7 +1380,7 @@ _lp_temp_sensors()
 _lp_temp_acpi()
 {
     local i
-    for i in $(acpi -t | sed 's/.* \([0-9]*\)\.[0-9]* degrees C$/\1/p'); do
+    for i in $(acpi -t | sed 's/.* \([-]\?[0-9]*\)\.[0-9]* degrees C$/\1/p'); do
         [[ $i -gt $temperature ]] && temperature=$i
     done
 }


### PR DESCRIPTION
ACPI returns negative temperature when a card is not active : 
    Thermal 0: ok, -267.8 degrees C
The previous regexp was not catching it, so there was an error in the bash.
