### PR TITLE
Fix for bash, source was failing, switched to alt function declaration.

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -1732,7 +1732,7 @@ prompt_on()
         #        time _lp_set_prompt
         #    }
         #else
-            function precmd {
+            precmd() {
                 _lp_set_prompt
             }
         #fi


### PR DESCRIPTION
The problem:
$ source liquidprompt
-bash: ./liquidprompt: line 1729: syntax error near unexpected token `}'
-bash: ./liquidprompt: line 1729:`            }'

My bash info:
$ bash --version
GNU bash, version 3.2.51(1)-release (x86_64-apple-darwin13)

NOTE: Output of test.sh is the same before and after this fix.  Looks like errors in the test output but I'm not sure of the meaning.
