### PR TITLE
Update example.bashrc to avoid #278, etc.

### DIFF
--- a/example.bashrc
+++ b/example.bashrc
@@ -18,6 +18,5 @@ fi
 # If you have your own config for the liquid prompt, edit and uncomment this line:
 # source /path/to/liquidpromptrc
 
-# Use the liquidprompt
-source ~/.liquidprompt
-
+# Use the liquidprompt if interactive shell
+[[ $- = *i* ]] && source ~/.liquidprompt


### PR DESCRIPTION
Only load liquidprompt if the shell is interactive (see #278)
