### PR TITLE
Fixed battery status on Apple computers without battery, like iMacs.

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -1153,7 +1153,7 @@ case "$LP_OS" in
         local bat="$(cut -f2 <<<"$pmset")"
         bat="${bat%%%*}"
         case "$pmset" in
-            *charged*)
+            *charged* | "")
             return 4
             ;;
             *discharging*)


### PR DESCRIPTION
Fix battery status when there is no battery in the computer #315.

`pmset -g batt` returns only `Now drawing from 'AC Power'`, so the **bat** variable will contain empty string.
