### PR TITLE
hide sensors errors (if any)

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -1371,7 +1371,7 @@ _lp_temp_sensors()
 {
     # Return the hottest system temperature we get through the sensors command
     local i
-    for i in $(sensors |
+    for i in $(sensors 2>/dev/null |
             sed -n -r "s/^(CPU|SYS|MB|Core|temp).*: *\+([0-9]*)\..°.*/\2/p"); do
         [[ $i -gt $temperature ]] && temperature=$i
     done


### PR DESCRIPTION
example on a a CentOS release 5.6:
$ sensors
No sensors found!
Make sure you loaded all the kernel drivers you need.
Try sensors-detect to find out which these are.

without this commit, this output is displayed before each prompt
(in the default installation/configuration)
