### PR TITLE
Clarify theme configuration file in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,8 @@ To erase your new formatting, just bind `LP_PS1` to a null string:
 ## Themes
 
 You can change the colors and special characters of some parts of Liquid Prompt
-by sourcing your favorite theme file (`*.theme`) in the configuration file.
+by sourcing your favorite theme file (`*.theme`) in the configuration file. See
+[`liquid.theme`](liquid.theme) for an example of the default Liquid Prompt theme.
 
 ### Colors
 


### PR DESCRIPTION
I think providing a direct link to `liquid.theme` in the README should clarify how to theme Liquid Prompt (and also close #156).
