### PR TITLE
Add support for more hostname colours

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -15,6 +15,8 @@
 	- Git:
 	    * Also show the number of commits behind the remote (Github #269)
 	- Add variable LP_TTYN: the basename of the terminal (Github #357)
+	- Hostname:
+	    * Support more hostname colours on compatiable terminals.
 	Bug fixes:
 	- Git:
 	    * Fix typo in git work directory detection
@@ -28,7 +30,7 @@
 	- Documentation:
 	    * Many small fixes
 
-	Thanks to Matt Fletcher (@MaffooBristol), Kevin Yap (iKevinY), Sean
+	Thanks to Matt Fletcher (@MaffooBristol), Kevin Yap (@iKevinY), Sean
 	Hussey (@seanhussey), François Schmidts (@jaesisvsm), Morgan Knicely
 	(@morganizeit), Daniel Serodio (@dserodio), Jonathan Giddy
 	(@jongiddy)...

--- a/liquidprompt
+++ b/liquidprompt
@@ -252,11 +252,17 @@ _lp_source_config()
     # NO_COL is special: it will be used at runtime, not just during config loading
     NO_COL="${_LP_OPEN_ESC}${ti_sgr0}${_LP_CLOSE_ESC}"
 
-    # compute the hash of the hostname
-    # and get the corresponding number in [1-6] (red,green,yellow,blue,purple or cyan)
-    # FIXME check portability of cksum and add more formats (bold? 256 colors?)
-    local hash=$(( 1 + $(hostname | cksum | cut -d " " -f 1) % 6 ))
-    LP_COLOR_HOST_HASH="${_LP_OPEN_ESC}$(ti_setaf $hash)${_LP_CLOSE_ESC}"
+    # Assume 256-color terminal if $COLORTERM is set, else fall back to tput colors
+    local -i colors
+    if [[ -n "$COLORTERM" ]]; then colors=256; else colors=$(tput colors); fi
+
+    # Pick an arbitrary color based on checksum of hostname; choose from the
+    # first 75% of available colors because some colors available to 256-color
+    # terminals are difficult or impossible to read on a white background.
+    # (see https://github.com/nojhan/liquidprompt/issues/339 for details)
+    local HASH_MOD=$(($colors * 3/4))
+    local HOST_COLOR=$((1 + $(hostname | cksum | cut -d " " -f 1) % $HASH_MOD))
+    LP_COLOR_HOST_HASH="${_LP_OPEN_ESC}$(ti_setaf $HOST_COLOR)${_LP_CLOSE_ESC}"
 
     unset ti_sgr0 ti_bold ti_setaf ti_setab
 


### PR DESCRIPTION
I noticed that the hostname colours only support 6 different colours, even on terminals where many more colours are available. I used the following command to check all of the available colours on my `xterm-256color` terminal with two different colour schemes (the default OS X Terminal theme with a white background and a darker one that I use on a regular basis):

``` bash
for i in {1..255}; do tput setaf $i; echo -n "$i "; done
```

![Light](https://cloud.githubusercontent.com/assets/2434728/5551102/3d89a250-8b70-11e4-9304-6f970a4429a4.png)
![Dark](https://cloud.githubusercontent.com/assets/2434728/5551103/3d8aedea-8b70-11e4-9d8e-183a8372b7ac.png)

On the white background, there is an issue with colours 226–231 being extremely difficult (or impossible) to read. Therefore, I opted to use `tput colors` to detect the number of colours that are available, and taking 75% of those colours. This has a couple benefits:
- The previous behaviour of the hostname colour algorithm chose a random colour in the interval [1, 6]. This implementation behaves exactly the same when the output of `tput colors` is 8.
- 75% of 256 is 192, and choosing a colour in the interval [1, 192] avoids the use of colours 226–231 on `xterm-256color` terminals.

However, I'm not too certain about how well this solution will work on other systems, since I've only tested it on my OS X machine. Is it reasonable to assume that `tput colors` will be available everywhere? If not, I presume it would be a pretty trivial patch (just falling back to `% 6` if `tput colors` is unavailable).
