### PR TITLE
Add LP_TTYN variable to display terminal number.

### DIFF
--- a/liquid.ps1
+++ b/liquid.ps1
@@ -17,6 +17,7 @@
 # LP_ERR last error code
 # LP_MARK prompt mark
 # LP_TIME current time
+# LP_TTYN number of current terminal (useful in title for quick switching)
 # LP_RUNTIME runtime of last command
 # LP_MARK_PREFIX user-defined prompt mark prefix (helpful if you want 2-line prompts)
 # LP_PS1_PREFIX user-defined general-purpose prefix (default set a generic prompt as the window title)

--- a/liquidprompt
+++ b/liquidprompt
@@ -69,6 +69,7 @@ if test -n "$BASH_VERSION" -a -n "$PS1" ; then
     _LP_USER_SYMBOL="\u"
     _LP_HOST_SYMBOL="\h"
     _LP_TIME_SYMBOL="\t"
+    _LP_TTYN_SYMBOL="\l"
     _LP_MARK_SYMBOL='\$'
     _LP_FIRST_INDEX=0
     _LP_PWD_SYMBOL="\\w"
@@ -86,6 +87,7 @@ elif test -n "$ZSH_VERSION" ; then
     _LP_USER_SYMBOL="%n"
     _LP_HOST_SYMBOL="%m"
     _LP_TIME_SYMBOL="%*"
+    _LP_TTYN_SYMBOL="%l"
     _LP_MARK_SYMBOL='%(!.#.%%)'
     _LP_FIRST_INDEX=1
     _LP_PERCENT='%%'
@@ -490,6 +492,8 @@ fi
 #################
 # Where are we? #
 #################
+
+LP_TTYN="${_LP_TTYN_SYMBOL}"
 
 _lp_connection()
 {


### PR DESCRIPTION
This is a simple addition, which I find particularly useful added at the start of the terminal titlebar, to make it quicker to switch between terminals with similar titles.