### PR TITLE
Put 12 o'clock clock face at array index 0

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -1493,9 +1493,9 @@ _lp_time_analog()
     #
 
     local -a plain
-    plain=(🕐 🕑 🕒 🕓 🕔 🕕 🕖 🕗 🕘 🕙 🕚 🕛 )
+    plain=(🕛 🕐 🕑 🕒 🕓 🕔 🕕 🕖 🕗 🕘 🕙 🕚 )
     local -a half
-    half=(🕜 🕝 🕞 🕟 🕠 🕡 🕢 🕣 🕤 🕥 🕦 🕧 )
+    half=(🕧 🕜 🕝 🕞 🕟 🕠 🕡 🕢 🕣 🕤 🕥 🕦 )
 
     # "date %I" returns a number between 1 and 12 and we want 12 to be 0.
     local -i hi=$(( hour % 12))


### PR DESCRIPTION
I was experiencing an issue on OS X Yosemite where the clock was always displaying an hour ahead.  I think this fixed the issue, since 12 % 12 should equal 0, so I would expect the clock face for 12 o'clock to be at index 0.  This seems to have fixed the issue for me.