### PR TITLE
fixed detection of ssh and tmux local sessions

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -493,13 +493,13 @@ fi
 
 _lp_connection()
 {
-    if [[ -n "$SSH_CLIENT$SSH2_CLIENT$SSH_TTY" ]] ; then
+    if [[ -n "$SSH_CLIENT$SSH2_CLIENT$SSH_TTY$SSH_CONNECTION" ]] ; then
         echo ssh
     else
         # TODO check on *BSD
         local sess_src="$(who am i | sed -n 's/.*(\(.*\))/\1/p')"
         local sess_parent="$(ps -o comm= -p $PPID 2> /dev/null)"
-        if [[ -z "$sess_src" || "$sess_src" = ":"* ]] ; then
+        if [[ -z "$sess_src" || "$sess_src" = ":"* || "$sess_parent" = "tmux" || "$sess_parent" = "screen" ]] ; then
             echo lcl  # Local
         elif [[ "$sess_parent" = "su" || "$sess_parent" = "sudo" ]] ; then
             echo su   # Remote su/sudo


### PR DESCRIPTION
At least new versions of tmux (running v2.0), the detection of ssh and
local sessions did not work proper.

Since some update of tmux, only `SSH_CONNECTION` will be kept when
starting tmux during an SSH session. So I just added this one to
`_lp_connection`.

For local sessions, liquidprompt thought to run via telnet. I think this
is related to the tmux update as well. However, tmux shows this for who
am i:
```
   guest    pts/4        2015-05-19 20:28 (tmux(1938).%3)
```
Which breaks the local detection.
Since `sess_parent` is already known in `_lp_connection`, I use this to
check "this" for being either tmux or screen.