### PR TITLE
_lp_shorten_path: fix error when parsing folder with special characters

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -628,7 +628,7 @@ _lp_shorten_path()
     else
         # len is over max len, show at least LP_PATH_KEEP leading dirs and
         # current directory
-        local tmp=${p//\//}
+        local tmp="${p//\//}"
         local -i delims=$(( ${#p} - ${#tmp} ))
 
         for (( dir=0; dir < LP_PATH_KEEP; dir++ )); do


### PR DESCRIPTION
I discovered that changing directory with a long folder *including spaces and dots* raise an error message.

## Issues
1. an error message shows up
2. the current directory in the prompt does not update

## How to reproduce
```
% cd verylong\ folder\ with\ a.dot
_lp_shorten_path:local:31: not valid in this context: a.dot 
``` 
* the problem only appears in zsh; bash does not seem to be affected
* the issue is easier to reproduce with a narrow window ($COLUMNS is smaller) 
