### PR TITLE
hide GREP_OPTIONS values to avoid "conflicting matchers" error

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -486,7 +486,7 @@ if [[ "$EUID" -ne "0" ]]; then  # if user is not root
     # "sudo -n" is only supported from sudo 1.7.0
     if [[ "$LP_ENABLE_SUDO" = 1 ]] \
             && command -v sudo >/dev/null \
-            && LC_MESSAGES=C sudo -V | grep -qE '^Sudo version (1(\.([789]\.|[1-9][0-9])|[0-9])|[2-9])'
+            && LC_MESSAGES=C sudo -V | GREP_OPTIONS= \grep -qE '^Sudo version (1(\.([789]\.|[1-9][0-9])|[0-9])|[2-9])'
     then
         LP_COLOR_MARK_NO_SUDO="$LP_COLOR_MARK"
         # Test the code with the commands:
@@ -1592,6 +1592,7 @@ _lp_set_prompt()
     # Reset IFS to its default value to avoid strange behaviors
     # (in case the user is playing with the value at the prompt)
     local IFS="$_LP_IFS"
+    local GREP_OPTIONS=
 
     # execute the old prompt
     if $_LP_SHELL_bash; then


### PR DESCRIPTION
If GREP_OPTIONS env variable is set *grep* can error out, e.g.

$ GREP_OPTIONS=-P \grep -F foo bar
grep: conflicting matchers specified

This patch locally resets GREP_OPTIONS and escapes *grep* at one place that was missed  before.

Peter
