### PR TITLE
Added support for tab colors based on CD in iTerm

### DIFF
--- a/liquid.theme
+++ b/liquid.theme
@@ -116,6 +116,32 @@ LP_COLOR_VIRTUALENV="$CYAN"
 # Runtime
 LP_COLOR_RUNTIME="$YELLOW"
 
+# Define folder name and color
+TAB_COLOR () {
+    if [ "${PWD/"FOLDERNAMEHERE"}" != "$PWD" ]; then
+      # First specified tab color
+      echo -ne "\033]6;1;bg;*;default\a"
+      echo -ne "\033]6;1;bg;red;brightness;255\a"
+      echo -ne "\033]6;1;bg;green;brightness;78\a"
+      echo -ne "\033]6;1;bg;blue;brightness;156\a"
+      echo -ne "\033]0;TABTITLEHERE\a"
+    elif [ "${PWD/"FOLDERNAMEHERE"}" != "$PWD" ]; then
+      # Second specified tab color
+      echo -ne "\033]6;1;bg;*;default\a"
+      echo -ne "\033]6;1;bg;red;brightness;126\a"
+      echo -ne "\033]6;1;bg;green;brightness;251\a"
+      echo -ne "\033]6;1;bg;blue;brightness;73\a"
+      echo -ne "\033]0;TABTITLEHERE\a"
+    else
+      # Default tab color  
+      echo -ne "\033]6;1;bg;*;default\a"
+      echo -ne "\033]6;1;bg;red;brightness;78\a"
+      echo -ne "\033]6;1;bg;green;brightness;255\a"
+      echo -ne "\033]6;1;bg;blue;brightness;176\a"
+      echo -ne "\033]0;TABTITLEHERE\a"
+    fi
+}
+
 # Color maps (battery and load levels)
 # Range from 0 (nothing special) to 9 (alert)
 LP_COLORMAP_0=""

--- a/liquidprompt
+++ b/liquidprompt
@@ -1636,6 +1636,10 @@ _lp_set_prompt()
         # Update directory icon for MacOS X
         $_LP_TERM_UPDATE_DIR
 
+        if [[ "$LP_ENABLE_TAB_COLOR" = 1 ]]; then
+            TAB_COLOR
+        fi
+
         LP_VCS=""
         LP_VCS_TYPE=""
         # LP_HOST is a global set at load time

--- a/liquidpromptrc-dist
+++ b/liquidpromptrc-dist
@@ -148,4 +148,7 @@ LP_ENABLE_SSH_COLORS=0
 # will be disabled
 LP_DISABLED_VCS_PATH=""
 
+# Use different tab colors for specified directories (only works with iterm)
+LP_ENABLE_TAB_COLOR=1
+
 # vim: set et sts=4 sw=4 tw=120 ft=sh:


### PR DESCRIPTION
Based on colors specified in the TAB COLOR function in the theme file, users can specify tab color changes in iTerm based on the current directory (includes all subdirectories of specified folder)