### PR TITLE
added stderr redirection to /dev/null for sensor command

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -1416,7 +1416,7 @@ _lp_temp_sensors()
     # Return the hottest system temperature we get through the sensors command
     # Only the integer part is retained
     local i
-    for i in $(sensors -u | sed -n 's/^  temp[0-9][0-9]*_input: \([0-9]*\)\..*$/\1/p'); do
+    for i in $(sensors 2> /dev/null -u | sed -n 's/^  temp[0-9][0-9]*_input: \([0-9]*\)\..*$/\1/p'); do
         [[ $i -gt $temperature ]] && temperature=$i
     done
 }


### PR DESCRIPTION
I am using liquidprompt on some debian 6 machines, every time I hit enter i get this very annoying message:

No sensors found!
Make sure you loaded all the kernel drivers you need.
Try sensors-detect to find out which these are.

This is printed out by the sensors command, I redirected the stderr to dev null for my convenience.
What do you think? Should I open an issue first?


