### PR TITLE
Better proxy detection

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -1557,7 +1557,7 @@ _lp_set_prompt()
     LP_TIME="$(_lp_sr "$(_lp_time)")"
 
     # in main prompt: no space
-    if [[ "$LP_ENABLE_PROXY,$http_proxy" = 1,?* ]] ; then
+    if [[ "$LP_ENABLE_PROXY,$http_proxy" = 1,?* || "$LP_ENABLE_PROXY,$HTTP_PROXY" = 1,?* || "$LP_ENABLE_PROXY,$ftp_proxy" = 1,?* || "$LP_ENABLE_PROXY,$FTP_PROXY" = 1,?* ]] ; then
         LP_PROXY="$LP_COLOR_PROXY$LP_MARK_PROXY$NO_COL"
     else
         LP_PROXY=


### PR DESCRIPTION
In Unix systems, the proxy environment variables can be uppercase or lowercase, but currently the script checks for _$http_proxy_.
Also, there could be the need to highlight the configuration of an FTP proxy, so I added the check for that variables too.

With this patch, the script will set _$LP_PROXY_ if it finds that at least one of the following variables are not empty:
- _$http_proxy_
- _$HTTP_PROXY_
- _$ftp_proxy_
- _$FTP_PROXY_