### PR TITLE
Correct _lp_load_color color scale

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -1398,7 +1398,7 @@ _lp_load_color()
     local -i load=${tmp:-0}/$_lp_CPUNUM
 
     if (( load > LP_LOAD_THRESHOLD )); then
-        local ret="$(_lp_color_map $load 200)${LP_MARK_LOAD}"
+        local ret="$(_lp_color_map $load)${LP_MARK_LOAD}"
 
         if [[ "$LP_PERCENTS_ALWAYS" == 1 ]]; then
             ret="${ret}${load}${_LP_PERCENT}"


### PR DESCRIPTION
Like the CPU load is divided by CPUNUM, I think the value is always between 0..100, isn't it?

So, why use a custom scale of 200 to colorize the output of _lp_load_color()?

Maybe, I made a mistake and don't understand something (in this case, drop this PR)…