### PR TITLE
Revert "LP_TTYN: simplify/optimize the implementation"

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -69,6 +69,7 @@ if test -n "$BASH_VERSION" -a -n "$PS1" ; then
     _LP_USER_SYMBOL="\u"
     _LP_HOST_SYMBOL="\h"
     _LP_TIME_SYMBOL="\t"
+    _LP_TTYN_SYMBOL="\l"
     _LP_MARK_SYMBOL='\$'
     _LP_FIRST_INDEX=0
     _LP_PWD_SYMBOL="\\w"
@@ -86,6 +87,7 @@ elif test -n "$ZSH_VERSION" ; then
     _LP_USER_SYMBOL="%n"
     _LP_HOST_SYMBOL="%m"
     _LP_TIME_SYMBOL="%*"
+    _LP_TTYN_SYMBOL="%l"
     _LP_MARK_SYMBOL='%(!.#.%%)'
     _LP_FIRST_INDEX=1
     _LP_PERCENT='%%'
@@ -452,10 +454,6 @@ fi
 # Default value for LP_PERM when LP_ENABLE_PERM is 0
 LP_PERM=:   # without color
 
-# Same as bash '\l', but inlined as a constant as the value will not change
-# during the shell's life
-LP_TTYN="$(basename $(tty))"
-
 
 # Escape the given strings
 # Must be used for all strings that may comes from remote sources,
@@ -521,6 +519,8 @@ fi
 #################
 # Where are we? #
 #################
+
+LP_TTYN="${_LP_TTYN_SYMBOL}"
 
 _lp_connection()
 {


### PR DESCRIPTION
This reverts commit b67434a61eec3f90bde983d083935e4ca854266d.

The commit message of the reverted commit was about optimizing the TTY detection. Instead of relying on the shell's builtin functionality the commit ran the 'tty' command and cached the results.

Unfortunately this breaks when a tty hasn't been allocated yet. This is what I was seeing both on a local terminals and (some) remote ssh connections:
```
basename: extra operand ‘tty’
Try 'basename --help' for more information.
```
With the commit reverted all is well and this error never appears.