### PR TITLE
ZSH runtime (precmd/preexec corrections to previous PR #355)

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,7 +353,6 @@ version 3](LICENSE).
 * The analog clock requires a Unicode-aware terminal and at least a
   sufficiently complete font on your system. The [Symbola](http://users.teilar.gr/~g1951d/)
   font, designed by Georges Douros, is known to work well.
-* Displaying the runtime currently only works with Bash.
 
 
 ## Authors

--- a/liquidprompt
+++ b/liquidprompt
@@ -46,6 +46,7 @@
 # Rolf Morel        <rolfmorel@gmail.com>         # "Shorten path" refactoring and fixes
 # Thomas Debesse    <thomas.debesse@gmail.com>    # Fix columns use.
 # Yann 'Ze' Richard <ze@nbox.org>                 # Do not fail on missing commands.
+# Austen Adler      <stonewareslord@gmail.com>    # ZSH runtime
 
 # See the README.md file for a summary of features.
 
@@ -290,11 +291,7 @@ _lp_source_config()
     LP_ENABLE_HG=${LP_ENABLE_HG:-1}
     LP_ENABLE_BZR=${LP_ENABLE_BZR:-1}
     LP_ENABLE_TIME=${LP_ENABLE_TIME:-0}
-    if $_LP_SHELL_bash; then
-        LP_ENABLE_RUNTIME=${LP_ENABLE_RUNTIME:-1}
-    else
-        LP_ENABLE_RUNTIME=${LP_ENABLE_RUNTIME:-0}
-    fi
+    LP_ENABLE_RUNTIME=${LP_ENABLE_RUNTIME:-1}
     LP_ENABLE_VIRTUALENV=${LP_ENABLE_VIRTUALENV:-1}
     LP_ENABLE_SCLS=${LP_ENABLE_SCLS:-1}
     LP_ENABLE_VCS_ROOT=${LP_ENABLE_VCS_ROOT:-0}
@@ -414,11 +411,6 @@ command -v tmux >/dev/null   ; _lp_bool _LP_ENABLE_TMUX $?
 $_LP_ENABLE_SCREEN || $_LP_ENABLE_TMUX ; _lp_bool _LP_ENABLE_DETACHED_SESSIONS $?
 # Use standard path symbols inside Midnight Commander
 [[ -n "$MC_SID" ]] && LP_ENABLE_SHORTEN_PATH=0
-
-if [[ "$LP_ENABLE_RUNTIME" == 1 ]] && ! $_LP_SHELL_bash; then
-    echo Unfortunately, runtime printing for zsh is not yet supported. Turn LP_ENABLE_RUNTIME off in your config to hide this message.
-    LP_ENABLE_RUNTIME=0
-fi
 
 # If we are running in a terminal multiplexer, brackets are colored
 if [[ "$TERM" == screen* ]]; then
@@ -1362,8 +1354,21 @@ _lp_reset_runtime()
 
 if [ "$LP_ENABLE_RUNTIME" = 1 ]
 then
-    # _lp_reset_runtime gets called whenever bash executes a command
-    trap '_lp_reset_runtime' DEBUG
+    if "$_LP_SHELL_zsh"; then
+        precmd() {
+          if [ $timer ]; then
+            export _LP_RUNTIME_SECONDS=$(($SECONDS - $timer))
+            unset timer
+          fi
+        }
+
+        preexec() {
+          export timer=${timer:-$SECONDS}
+        }
+    else
+        # _lp_reset_runtime gets called whenever bash executes a command
+        trap '_lp_reset_runtime' DEBUG
+    fi
 fi
 
 ###############

--- a/liquidprompt
+++ b/liquidprompt
@@ -96,6 +96,11 @@ else
     return
 fi
 
+# For ZSH, autoload required functions
+if $_LP_SHELL_zsh; then
+    autoload -Uz add-zsh-hook
+fi
+
 # Store $2 (or $?) as a true/false value in variable named $1
 # $? is propagated
 #   _lp_bool foo 5
@@ -1365,10 +1370,8 @@ then
         _lp_runtime_preexec() {
           export timer=${timer:-$SECONDS}
         }
-        typeset -ga precmd_functions
-        precmd_functions+=(_lp_runtime_precmd)
-        typeset -ga preexec_functions
-        preexec_functions+=(_lp_runtime_preexec)
+        add-zsh-hook precmd _lp_runtime_precmd
+        add-zsh-hook preexec _lp_runtime_preexec
     else
         # _lp_reset_runtime gets called whenever bash executes a command
         trap '_lp_reset_runtime' DEBUG
@@ -1786,9 +1789,7 @@ prompt_on()
         #        time _lp_set_prompt
         #    }
         #else
-            _lp_main_precmd() {
-                _lp_set_prompt
-            }
+            add-zsh-hook precmd _lp_set_prompt
         #fi
     fi
 }
@@ -1801,7 +1802,7 @@ prompt_off()
         eval "$LP_OLD_SHOPT"
         PROMPT_COMMAND="$LP_OLD_PROMPT_COMMAND"
     else # zsh
-        _lp_main_precmd() { : ; }
+        add-zsh-hook -d precmd _lp_set_prompt
         eval "$LP_OLD_PROMPT_COMMAND"
     fi
 }
@@ -1814,16 +1815,10 @@ prompt_OFF()
         shopt -u promptvars
         PROMPT_COMMAND="$LP_OLD_PROMPT_COMMAND"
     else # zsh
-        _lp_main_precmd() { : ; }
+        add-zsh-hook -d precmd _lp_set_prompt
         eval "$LP_OLD_PROMPT_COMMAND"
     fi
 }
-
-# Add _lp_main_precmd to global precmd hook
-if $_LP_SHELL_zsh; then
-    typeset -ga precmd_functions
-    precmd_functions+=(_lp_main_precmd)
-fi
 
 # By default, sourcing liquidprompt will activate Liquid Prompt
 prompt_on

--- a/liquidprompt
+++ b/liquidprompt
@@ -1355,16 +1355,20 @@ _lp_reset_runtime()
 if [ "$LP_ENABLE_RUNTIME" = 1 ]
 then
     if "$_LP_SHELL_zsh"; then
-        precmd() {
+        _lp_runtime_precmd() {
           if [ $timer ]; then
             export _LP_RUNTIME_SECONDS=$(($SECONDS - $timer))
             unset timer
           fi
         }
 
-        preexec() {
+        _lp_runtime_preexec() {
           export timer=${timer:-$SECONDS}
         }
+        typeset -ga precmd_functions
+        precmd_functions+=(_lp_runtime_precmd)
+        typeset -ga preexec_functions
+        preexec_functions+=(_lp_runtime_preexec)
     else
         # _lp_reset_runtime gets called whenever bash executes a command
         trap '_lp_reset_runtime' DEBUG
@@ -1777,12 +1781,12 @@ prompt_on()
     else # zsh
         # That doesn't seem to work: no time output
         #if [[ "$LP_DEBUG_TIME" == 1 ]]; then
-        #    precmd() {
+        #    _lp_main_precmd() {
         #        local TIMEFMT='Liquid Prompt build time: %*E'
         #        time _lp_set_prompt
         #    }
         #else
-            precmd() {
+            _lp_main_precmd() {
                 _lp_set_prompt
             }
         #fi
@@ -1797,7 +1801,7 @@ prompt_off()
         eval "$LP_OLD_SHOPT"
         PROMPT_COMMAND="$LP_OLD_PROMPT_COMMAND"
     else # zsh
-        precmd() { : ; }
+        _lp_main_precmd() { : ; }
         eval "$LP_OLD_PROMPT_COMMAND"
     fi
 }
@@ -1810,10 +1814,16 @@ prompt_OFF()
         shopt -u promptvars
         PROMPT_COMMAND="$LP_OLD_PROMPT_COMMAND"
     else # zsh
-        precmd() { : ; }
+        _lp_main_precmd() { : ; }
         eval "$LP_OLD_PROMPT_COMMAND"
     fi
 }
+
+# Add _lp_main_precmd to global precmd hook
+if $_LP_SHELL_zsh; then
+    typeset -ga precmd_functions
+    precmd_functions+=(_lp_main_precmd)
+fi
 
 # By default, sourcing liquidprompt will activate Liquid Prompt
 prompt_on


### PR DESCRIPTION
This is just a rebase of the previous PR #355 by @stonewareslord on top of develop.

Additionally, I made it actually work by using precmd/preexec *_functions arrays instead of just as single function (which would be overwritten by prompt_off/prompt_on)