### PR TITLE
LP_HOSTNAME_ALWAYS=-1 to never show hostname

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -548,46 +548,52 @@ _lp_connection()
 # The connection is not expected to change from inside the shell, so we
 # build this just once
 LP_HOST=""
-[[ -r /etc/debian_chroot ]] && LP_HOST="($(< /etc/debian_chroot))"
 
-# Which host symbol should we use?
-if [[ "${LP_ENABLE_FQDN}" -eq "1" ]] ; then
-    LP_HOST_SYMBOL="${_LP_FQDN_SYMBOL}"
-else
-    LP_HOST_SYMBOL="${_LP_HOST_SYMBOL}"
-fi
+# Only process hostname elements if we haven't turned them off
+if [[ "${LP_HOSTNAME_ALWAYS}" -ne "-1" ]]; then
 
-# If we are connected with a X11 support
-if [[ -n "$DISPLAY" ]]; then
-    LP_HOST="${LP_COLOR_X11_ON}${LP_HOST}@${NO_COL}"
-else
-    LP_HOST="${LP_COLOR_X11_OFF}${LP_HOST}@${NO_COL}"
-fi
+    [[ -r /etc/debian_chroot ]] && LP_HOST="($(< /etc/debian_chroot))"
 
-case "$(_lp_connection)" in
-lcl)
-    if [[ "${LP_HOSTNAME_ALWAYS}" -eq "0" ]]; then
-        # FIXME do we want to display the chroot if local?
-        LP_HOST="" # no hostname if local
+    # Which host symbol should we use?
+    if [[ "${LP_ENABLE_FQDN}" -eq "1" ]] ; then
+        LP_HOST_SYMBOL="${_LP_FQDN_SYMBOL}"
     else
-        LP_HOST="${LP_HOST}${LP_COLOR_HOST}${LP_HOST_SYMBOL}${NO_COL}"
+        LP_HOST_SYMBOL="${_LP_HOST_SYMBOL}"
     fi
-    ;;
-ssh)
-    # If we want a different color for each host
-    [[ "$LP_ENABLE_SSH_COLORS" -eq 1 ]] && LP_COLOR_SSH="$LP_COLOR_HOST_HASH"
-    LP_HOST="${LP_HOST}${LP_COLOR_SSH}${_LP_HOST_SYMBOL}${NO_COL}"
-    ;;
-su)
-    LP_HOST="${LP_HOST}${LP_COLOR_SU}${LP_HOST_SYMBOL}${NO_COL}"
-    ;;
-tel)
-    LP_HOST="${LP_HOST}${LP_COLOR_TELNET}${LP_HOST_SYMBOL}${NO_COL}"
-    ;;
-*)
-    LP_HOST="${LP_HOST}${LP_HOST_SYMBOL}" # defaults to no color
-    ;;
-esac
+
+    # If we are connected with a X11 support
+    if [[ -n "$DISPLAY" ]]; then
+        LP_HOST="${LP_COLOR_X11_ON}${LP_HOST}@${NO_COL}"
+    else
+        LP_HOST="${LP_COLOR_X11_OFF}${LP_HOST}@${NO_COL}"
+    fi
+
+    case "$(_lp_connection)" in
+    lcl)
+        if [[ "${LP_HOSTNAME_ALWAYS}" -eq "0" ]]; then
+            # FIXME do we want to display the chroot if local?
+            LP_HOST="" # no hostname if local
+        else
+            LP_HOST="${LP_HOST}${LP_COLOR_HOST}${_LP_HOST_SYMBOL}${NO_COL}"
+        fi
+        ;;
+    ssh)
+        # If we want a different color for each host
+        [[ "$LP_ENABLE_SSH_COLORS" -eq 1 ]] && LP_COLOR_SSH="$LP_COLOR_HOST_HASH"
+        LP_HOST="${LP_HOST}${LP_COLOR_SSH}${_LP_HOST_SYMBOL}${NO_COL}"
+        ;;
+    su)
+        LP_HOST="${LP_HOST}${LP_COLOR_SU}${_LP_HOST_SYMBOL}${NO_COL}"
+        ;;
+    tel)
+        LP_HOST="${LP_HOST}${LP_COLOR_TELNET}${_LP_HOST_SYMBOL}${NO_COL}"
+        ;;
+    *)
+        LP_HOST="${LP_HOST}${_LP_HOST_SYMBOL}" # defaults to no color
+        ;;
+    esac
+
+fi
 
 # Useless now, so undefine
 unset _lp_connection

--- a/liquidpromptrc-dist
+++ b/liquidpromptrc-dist
@@ -35,6 +35,7 @@ LP_PATH_KEEP=2
 # Do you want to display the hostname, even if not connected through network?
 # Defaults to 0 (do not display hostname when locally connected)
 # set to 1 if you want to always see the hostname
+# set to -1 if you want to never see the hostname
 LP_HOSTNAME_ALWAYS=0
 
 # Use the FQDN instead of the short hostname if the hostname is displayed


### PR DESCRIPTION
On OS X, I've been having problems determining connection status, and often a local connection shows up as if it were Telnet (color: WARN_RED).

Instead of adding an LP_HOSTNAME_NEVER option, or changing the option name to LP_HOSTNAME and breaking existing configs, just added a value "2" that will prevent showing hostname at all.

I realize this is a hack, because I'd rather find out the terminal status properly, but I wasn't having much luck with that so this option will hopefully suffice for now.