### PR TITLE
git prompt enhancement if you are currently MERGING, REBASING or CHERRY-PICKING

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -857,6 +857,9 @@ _lp_git_branch_color()
 
         local end
         end="$NO_COL"
+		
+		end="$(_lp_git_head_status)$end"
+
         if LC_ALL=C \git status --porcelain 2>/dev/null | \grep -Eq '^\?\?'; then
             end="$LP_COLOR_CHANGES$LP_MARK_UNTRACKED$end"
         fi
@@ -933,6 +936,15 @@ _lp_git_branch_color()
         fi
         echo -nE "$ret$end"
     fi
+}
+
+# Display additional information of the 
+_lp_git_head_status() {
+	local gitdir
+	gitdir="$(\git rev-parse --git-dir 2>/dev/null)"
+	if [ -f "${gitdir}/MERGE_HEAD" ] ; then
+		echo "MERGING"
+	fi
 }
 
 # Search upwards through a directory structure looking for a file/folder with

--- a/liquidprompt
+++ b/liquidprompt
@@ -857,8 +857,8 @@ _lp_git_branch_color()
 
         local end
         end="$NO_COL"
-		
-		end="${LP_COLOR_CHANGES}$(_lp_git_head_status)${NO_COL}$end"
+        
+        end="${LP_COLOR_CHANGES}$(_lp_git_head_status)${NO_COL}$end"
 
         if LC_ALL=C \git status --porcelain 2>/dev/null | \grep -Eq '^\?\?'; then
             end="$LP_COLOR_CHANGES$LP_MARK_UNTRACKED$end"
@@ -941,15 +941,15 @@ _lp_git_branch_color()
 # Display additional information if HEAD is in merging, rebasing
 # or cherry-picking state
 _lp_git_head_status() {
-	local gitdir
-	gitdir="$(\git rev-parse --git-dir 2>/dev/null)"
-	if [ -f "${gitdir}/MERGE_HEAD" ] ; then
-		echo " MERGING"
-	elif [[ -d "${gitdir}/rebase-apply" ]] || [[ -d "${gitdir}/rebase-merge" ]] ; then
-		echo " REBASING"
-	elif [ -f "${gitdir}/CHERRY_PICK_HEAD" ] ; then
-		echo " CHERRY-PICKING"
-	fi
+    local gitdir
+    gitdir="$(\git rev-parse --git-dir 2>/dev/null)"
+    if [ -f "${gitdir}/MERGE_HEAD" ] ; then
+        echo " MERGING"
+    elif [[ -d "${gitdir}/rebase-apply" ]] || [[ -d "${gitdir}/rebase-merge" ]] ; then
+        echo " REBASING"
+    elif [ -f "${gitdir}/CHERRY_PICK_HEAD" ] ; then
+        echo " CHERRY-PICKING"
+    fi
 }
 
 # Search upwards through a directory structure looking for a file/folder with

--- a/liquidprompt
+++ b/liquidprompt
@@ -945,7 +945,7 @@ _lp_git_head_status() {
 	gitdir="$(\git rev-parse --git-dir 2>/dev/null)"
 	if [ -f "${gitdir}/MERGE_HEAD" ] ; then
 		echo " MERGING"
-	elif [ -d "${gitdir}/rebase-apply" ] ; then
+	elif [[ -d "${gitdir}/rebase-apply" ]] || [[ -d "${gitdir}/rebase-merge" ]] ; then
 		echo " REBASING"
 	elif [ -f "${gitdir}/CHERRY_PICK_HEAD" ] ; then
 		echo " CHERRY-PICKING"

--- a/liquidprompt
+++ b/liquidprompt
@@ -858,7 +858,7 @@ _lp_git_branch_color()
         local end
         end="$NO_COL"
 		
-		end="$(_lp_git_head_status)$end"
+		end="${LP_COLOR_CHANGES}$(_lp_git_head_status)${NO_COL}$end"
 
         if LC_ALL=C \git status --porcelain 2>/dev/null | \grep -Eq '^\?\?'; then
             end="$LP_COLOR_CHANGES$LP_MARK_UNTRACKED$end"
@@ -938,12 +938,13 @@ _lp_git_branch_color()
     fi
 }
 
-# Display additional information of the 
+# Display additional information if HEAD is in merging, rebasing
+# or cherry-picking state
 _lp_git_head_status() {
 	local gitdir
 	gitdir="$(\git rev-parse --git-dir 2>/dev/null)"
 	if [ -f "${gitdir}/MERGE_HEAD" ] ; then
-		echo "MERGING"
+		echo " MERGING"
 	fi
 }
 

--- a/liquidprompt
+++ b/liquidprompt
@@ -945,6 +945,10 @@ _lp_git_head_status() {
 	gitdir="$(\git rev-parse --git-dir 2>/dev/null)"
 	if [ -f "${gitdir}/MERGE_HEAD" ] ; then
 		echo " MERGING"
+	elif [ -d "${gitdir}/rebase-apply" ] ; then
+		echo " REBASING"
+	elif [ -f "${gitdir}/CHERRY_PICK_HEAD" ] ; then
+		echo " CHERRY-PICKING"
 	fi
 }
 


### PR DESCRIPTION
This commits adds the information MERGING, REBASING or CHERRY-PICKING after the branch name if your HEAD is in one of these states.

Tested with bash and zsh:

git init
git commit --allow-empty -mm
git checkout -b br1
echo 1 > test
git add .
git commit -mm
git checkout master
git checkout -b br2
echo 2 > test
git add .
git commit -mm

git merge br1
git merge --abort
git rebase br1
git rebase --abort
git cherry-pick br1
git cherry-pick --abort


