### PR TITLE
liquidprompt: redirect acpi -t stderr to /dev/null

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -1444,7 +1444,7 @@ _lp_temp_acpi()
 {
     local i
     # Only the integer part is retained
-    for i in $(LANG=C acpi -t | sed 's/.* \(-\?[0-9]*\)\.[0-9]* degrees C$/\1/p'); do
+    for i in $(LANG=C acpi -t 2>/dev/null | sed 's/.* \(-\?[0-9]*\)\.[0-9]* degrees C$/\1/p'); do
         [[ $i -gt $temperature ]] && temperature=$i
     done
 }


### PR DESCRIPTION
Let's prevent acpi from reporting missing support for devices.
We are only interested in data. If there is no data, ignore it.

This is related to issue #410

Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero.glez@gmail.com>