### PR TITLE
Force echo to enable "\." expansion for title escape sequences

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -1491,9 +1491,9 @@ _lp_title()
     (( LP_ENABLE_TITLE )) || return
 
     # Get the current computed prompt as pure text
-    echo -nE "${_LP_OPEN_ESC}${LP_TITLE_OPEN}"
+    echo -ne "${_LP_OPEN_ESC}${LP_TITLE_OPEN}"
     _lp_as_text "$1"
-    echo -nE "${LP_TITLE_CLOSE}${_LP_CLOSE_ESC}"
+    echo -ne "${LP_TITLE_CLOSE}${_LP_CLOSE_ESC}"
 }
 
 # Set the prompt mark to ± if git, to ☿ if mercurial, to ‡ if subversion


### PR DESCRIPTION
`LP_TITLE_OPEN` & `LP_TITLE_CLOSE` need the "\\." expansion, so explicitly enable it.

A screenshot:
![set_title](https://cloud.githubusercontent.com/assets/1031390/11845450/a8a73afa-a41c-11e5-811f-5ba4f40faa17.jpg)