### PR TITLE
avoid “No support for device type: thermal” messages from “acpi”

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -1380,7 +1380,7 @@ _lp_temp_sensors()
 _lp_temp_acpi()
 {
     local i
-    for i in $(LANG=C acpi -t | sed 's/.* \(-\?[0-9]*\)\.[0-9]* degrees C$/\1/p'); do
+    for i in $(LANG=C acpi -t 2>/dev/null | sed 's/.* \(-\?[0-9]*\)\.[0-9]* degrees C$/\1/p'); do
         [[ $i -gt $temperature ]] && temperature=$i
     done
 }


### PR DESCRIPTION
Hi, this modification suppress the annoying “No support for device type: thermal” message displayed at every prompt when there is no acpi thermal stuff.