### PR TITLE
Load exactly one configuration file, searching XDG_CONFIG_DIRS

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -418,14 +418,15 @@ _lp_source_config()
     if [[ -f "$HOME/.liquidpromptrc" ]]; then
         configfile="$HOME/.liquidpromptrc"
     else
+        local first
         local search
         # trailing ":" is so that ${search#*:} always removes something
         search="${XDG_CONFIG_HOME:-"$HOME/.config"}:${XDG_CONFIG_DIRS:-/etc/xdg}:"
         while [[ -n "$search" ]]; do
-            path="${search%%:*}"
+            first="${search%%:*}"
             search="${search#*:}"
-            if [[ -f "$path/liquidpromptrc" ]]; then
-                configfile="$path/liquidpromptrc"
+            if [[ -f "$first/liquidpromptrc" ]]; then
+                configfile="$first/liquidpromptrc"
                 break
             fi
         done


### PR DESCRIPTION
~/.liquidpromptrc is still the highest-priority, and
/etc/liquidpromptrc is still the lowest.

---

Rebased on `develop`, which already looks in the correct `$XDG_CONFIG_HOME` (not `$XDG_HOME_DIR` like `master` did), but does not do the full path-search behaviour described in the basedir spec.