### PR TITLE
Allow the colon to be customized

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,8 @@ Set the variable to a null string (`""`) if you do not want color.
 * `LP_MARK_STASH` (default: "+") if Git has stashed modifications
 * `LP_MARK_BRACKET_OPEN` (default: "[") marks around the main part of the prompt
 * `LP_MARK_BRACKET_CLOSE` (default: "]") marks around the main part of the prompt
+* `LP_MARK_PERM` (default: ":") colored green red or green to indicate write
+  permissions of the current directory
 * `LP_TITLE_OPEN` (default: "\e]0;") escape character opening a window's title
 * `LP_TITLE_CLOSE` (default: "\a") escape character closing a window's title
 

--- a/liquidprompt
+++ b/liquidprompt
@@ -356,6 +356,7 @@ _lp_source_config()
     LP_MARK_BRACKET_CLOSE="${LP_MARK_BRACKET_CLOSE:-"]"}"
     LP_MARK_SHORTEN_PATH="${LP_MARK_SHORTEN_PATH:-" … "}"
     LP_MARK_PREFIX="${LP_MARK_PREFIX:-" "}"
+    LP_MARK_PERM="${LP_MARK_PERM:-":"}"
 
     LP_COLOR_PATH=${LP_COLOR_PATH:-$BOLD}
     LP_COLOR_PATH_ROOT=${LP_COLOR_PATH_ROOT:-$BOLD_YELLOW}
@@ -523,7 +524,7 @@ else
 fi
 
 # Default value for LP_PERM when LP_ENABLE_PERM is 0
-LP_PERM=:   # without color
+LP_PERM=${LP_MARK_PERM}   # without color
 
 # Same as bash '\l', but inlined as a constant as the value will not change
 # during the shell's life
@@ -1759,11 +1760,12 @@ _lp_set_prompt()
         # LP_PERM: shows a ":"
         # - colored in green if user has write permission on the current dir
         # - colored in red if not
+        # - can set another symbol with LP_MARK_PERM
         if (( LP_ENABLE_PERM )); then
             if [[ -w "${PWD}" ]]; then
-                LP_PERM="${LP_COLOR_WRITE}:${NO_COL}"
+                LP_PERM="${LP_COLOR_WRITE}${LP_MARK_PERM}${NO_COL}"
             else
-                LP_PERM="${LP_COLOR_NOWRITE}:${NO_COL}"
+                LP_PERM="${LP_COLOR_NOWRITE}${LP_MARK_PERM}${NO_COL}"
             fi
         fi
 

--- a/liquidpromptrc-dist
+++ b/liquidpromptrc-dist
@@ -68,6 +68,10 @@ LP_PERCENTS_ALWAYS=1
 # Recommended value is 1
 LP_ENABLE_PERM=1
 
+# Use this character for the permisions feature
+# Defaults to colon (:)
+LP_MARK_PERM=:
+
 # Enable the proxy detection feature.
 # Recommended value is 1
 LP_ENABLE_PROXY=1


### PR DESCRIPTION
Now your lambda or arrow can take over the role of the colon.

Replaces #428
