### PR TITLE
Fix RPS1 variables not expanding

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -1876,7 +1876,7 @@ prompt_on()
         [[ -n "$_LP_ZSH_HOOK" ]] && add-zsh-hook -d precmd $_LP_ZSH_HOOK
         # Set options that affect PS1 evaluation
         # Disable parameter/command expansion; enable percent expansion
-        setopt promptpercent nopromptbang nopromptsubst
+        setopt promptpercent nopromptbang
         # 'time' doesn't seem to work on shell functions: no time output
         #if (( LP_DEBUG_TIME )); then
         #    _lp_main_precmd() {


### PR DESCRIPTION
Hello,
I updated to the latest version of liquidprompt (develop), and it broke my zsh right prompt.
I have some variables that are computed using the `precmd` in my `zshrc`, then these variables are displayed in the right prompt of zsh, using the `RPS1`.

A recent commit in `develop` set the `nopromptsubst`, this prevents the variables from expanding in the right prompt, leaving things like `$VARIABLES` instead. I did not fully understand why this was added in the first place, but removing it fixes the right prompt and I did not notice other problems occurring after.