### PR TITLE
Fixes LP_PATH_KEEP==-1 not working on zsh

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -718,11 +718,6 @@ _lp_shorten_path()
 
 if (( LP_ENABLE_SHORTEN_PATH )); then
     if (( LP_PATH_KEEP == -1 )); then
-        # _lp_shorten_path becomes a noop
-        _lp_shorten_path()
-        {
-            :
-        }
         # Will never change
         LP_PWD="${LP_COLOR_PATH}${_LP_DIR_SYMBOL}$NO_COL"
     fi


### PR DESCRIPTION
Hello,
I updated to the latest `develop` and it broke the path shortening behavior. To give a bit of context, I use `LP_ENABLE_SHORTEN_PATH=1` and `LP_PATH_KEEP=-1` (see #336), and I expect the path displayed to only contain the current directory. A recent optimization on `develop` breaks this behavior for zsh, instead I have the whole path displayed with a "1" appended at the end. Removing this optimization fixes the problem, without other errors occurring.

 