### PR TITLE
Fix PATH variable for zsh.

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -419,6 +419,7 @@ _lp_source_config()
         configfile="$HOME/.liquidpromptrc"
     else
         local search
+        local path
         # trailing ":" is so that ${search#*:} always removes something
         search="${XDG_CONFIG_HOME:-"$HOME/.config"}:${XDG_CONFIG_DIRS:-/etc/xdg}:"
         while [[ -n "$search" ]]; do


### PR DESCRIPTION
zsh interprets `path` as an array version of `PATH`, so 36914a089aee00ec1f41c96cb227638cbd0ec53c changed the PATH and broke almost everything for zsh users.