### PR TITLE
Add prefix and postfix not shown in title

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,27 @@ it to add a keyword to each of your different terminals:
     mycode [:~/code/liquidprompt] develop ±
 
 
+### Adding a Prefix/Postfix not shown in the title
+
+When using `LP_ENABLE_TITLE=1`, the prompt will be dispalyed as is in the window's title.
+To prefix or postfix the prompt only in the command line and not in the title,
+use `LP_PS1_PRETITLE` and `LP_PS1_POSTTITLE`.
+
+For example, if you want to add a line separator across all you terminal:
+
+    LP_PS1_PRETITLE="$(printf '%*s\n' $(tput cols) '' | tr ' ' '-')"
+
+If you want to customize the typing field:
+
+    LP_PS1_POSTTITLE="${WHITE}〉 "
+
+Note: in this example, you most probably want to reset the color of the output.
+You should thus add a call to a reset command before anything is run.
+In bash, you should add the following debug trap:
+
+    trap 'tput sgr0' DEBUG
+
+
 ### Rearranging the Prompt
 
 You can sort what you want to see by sourcing your favorite template file

--- a/liquidprompt
+++ b/liquidprompt
@@ -310,6 +310,8 @@ _lp_source_config()
     LP_PS1=${LP_PS1:-""}
     LP_PS1_PREFIX=${LP_PS1_PREFIX:-""}
     LP_PS1_POSTFIX=${LP_PS1_POSTFIX:-""}
+    LP_PS1_PRETITLE=${LP_PS1_PRETITLE:-""}
+    LP_PS1_POSTTITLE=${LP_PS1_POSTTITLE:-""}
 
     LP_ENABLE_PERM=${LP_ENABLE_PERM:-1}
     LP_ENABLE_SHORTEN_PATH=${LP_ENABLE_SHORTEN_PATH:-1}
@@ -1840,7 +1842,7 @@ _lp_set_prompt()
         LP_TITLE="$(_lp_title "$PS1")"
 
         # Insert it in the prompt
-        PS1="${LP_TITLE}${PS1}"
+        PS1="${LP_PS1_PRETITLE}${LP_TITLE}${PS1}${LP_PS1_POSTTITLE}"
 
         # Glue the bash prompt always go to the first column.
         # Avoid glitches after interrupting a command with Ctrl-C


### PR DESCRIPTION
When using LP_ENABLE_TITLE=1, the prompt will be dispalyed as is in the window's title. This could be a problem if you want to customize the prompt with fancy stuff, like a large horizontal line on a new line.

This feature add the LP_PS1_PRETITLE and LP_PS1_POSTTITLE variables, added to PS1 only after the LP_TITLE has been generated.

For example, if you want to add a line separator across all you terminal:

LP_PS1_PRETITLE="$(printf '%*s\n' $(tput cols) '' | tr ' ' '-')"

If you want to customize the typing field:

LP_PS1_POSTTITLE="${WHITE}〉 "
