### PR TITLE
fix colormap for values >= scale

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -1376,10 +1376,12 @@ _lp_battery_color()
 _lp_color_map() {
     # Default scale: 0..100
     # Custom scale: 0..$2
-    local -i scale idx
+    local -i scale val idx
     scale=${2:-100}
+    # value cannot be larger than scale-1
+    (( $1 >= scale )) && val=scale-1 || val=$1
     # Transform the value to a 0..${#COLOR_MAP} scale
-    idx=_LP_FIRST_INDEX+100*$1/scale/${#LP_COLORMAP[*]}
+    idx=_LP_FIRST_INDEX+100*val/scale/${#LP_COLORMAP[*]}
     echo -nE "${LP_COLORMAP[idx]}"
 }
 


### PR DESCRIPTION
# Problem

Currently if the value passed to _lp_color_map() is >= scale, the index lookup up in $LP_COLORMAP will be out of bounds and no color is returned. This means if the CPU load is at 100% or more, the value will have no color instead of the last one in the map.
# How to reproduce

```
prompt# _lp_color_map 99
[ some colored output ]
prompt# _lp_color_map 100
[ no output ]
prompt# _lp_color_map 125
[ no output ]
```

Or just load your system and watch the liquidprompt load indicator loose its colors as soon as the load gets to 100% and above.
# Fix

Any value >= scale should use the last color in the map. Do this by setting value to scale-1 if it is >= scale. This should work in any case and not just fix the cpu case. I think it never makes sense to let the value be >= scale.
