### PR TITLE
Make the maximum load a configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ You can configure some variables in the `~/.config/liquidpromptrc` file:
 
 * `LP_BATTERY_THRESHOLD`, the maximal value under which the battery level is displayed
 * `LP_LOAD_THRESHOLD`, the minimal value after which the load average is displayed
+* `LP_LOAD_SCALE_MAX`, the load that is considered the maximum when choosing colors
 * `LP_TEMP_THRESHOLD`, the minimal value after which the average temperature is displayed
 * `LP_RUNTIME_THRESHOLD`, the minimal value after which the runtime is displayed
 * `LP_PATH_LENGTH`, the maximum percentage of the screen width used to display the path

--- a/liquidprompt
+++ b/liquidprompt
@@ -298,6 +298,7 @@ _lp_source_config()
 
     # Default values (globals)
     LP_BATTERY_THRESHOLD=${LP_BATTERY_THRESHOLD:-75}
+    LP_LOAD_SCALE_MAX=${LP_LOAD_SCALE_MAX:-100}
     LP_LOAD_THRESHOLD=${LP_LOAD_THRESHOLD:-60}
     LP_TEMP_THRESHOLD=${LP_TEMP_THRESHOLD:-60}
     LP_RUNTIME_THRESHOLD=${LP_RUNTIME_THRESHOLD:-2}
@@ -1470,7 +1471,7 @@ _lp_load_color()
     local -i load=${lp_cpu_load:-0}/$_lp_CPUNUM
 
     if (( load > LP_LOAD_THRESHOLD )); then
-        local ret="$(_lp_color_map $load)${LP_MARK_LOAD}"
+        local ret="$(_lp_color_map $load $LP_LOAD_SCALE_MAX)${LP_MARK_LOAD}"
 
         if (( LP_PERCENTS_ALWAYS )); then
             ret+="${load}${_LP_PERCENT}"


### PR DESCRIPTION
This is a feature request to add a configuration option that allows the user to define what is considered the maximum load when choosing colors from the colormap.

The pull request adds a config option named LP_LOAD_SCALE_MAX that is passed to _lp_color_map() as second argument (scale) when the color for the load indicator is determined. LP_LOAD_SCALE_MAX defaults to 100 which is the default scale used by _lp_color_map(), so the status quo is not changed.

While it is not strictly necessary, it'd probably make sense to merge this together with my other pull request #455, which fixes colors for loads >= scale.

The second commit in this request is documentation only. Feel free to not merge it if you want to document this yourself.
