### PR TITLE
Display virtualenv parent dir name instead of its own.

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,14 @@ To erase your new formatting, just bind `LP_PS1` to a null string:
     export LP_PS1=""
 
 
+### Display virtualenv parent dir name
+
+If you would like to create your virtualenvs inside your projects with standart name like `venv`,you may want
+to see parent project name instead of standart `venv` (which now not handled by activate and can't be changed thought `--prompt`. To do this you can enable `LP_VIRTUALENV_PARENT`:
+
+  LP_VIRTUALENV_PARENT=1
+
+
 ## Themes
 
 You can change the colors and special characters of some parts of Liquid Prompt

--- a/liquidprompt
+++ b/liquidprompt
@@ -310,6 +310,7 @@ _lp_source_config()
     LP_PS1=${LP_PS1:-""}
     LP_PS1_PREFIX=${LP_PS1_PREFIX:-""}
     LP_PS1_POSTFIX=${LP_PS1_POSTFIX:-""}
+    LP_VIRTUALENV_PARENT=${LP_VIRTUALENV_PARENT:-0}
 
     LP_ENABLE_PERM=${LP_ENABLE_PERM:-1}
     LP_ENABLE_SHORTEN_PATH=${LP_ENABLE_SHORTEN_PATH:-1}
@@ -1716,7 +1717,11 @@ _lp_set_prompt()
     # Display the current Python virtual environment, if available
     if [[ "$LP_ENABLE_VIRTUALENV,${VIRTUAL_ENV-}${CONDA_DEFAULT_ENV-}" = 1,?* ]]; then
         if [[ -n "${VIRTUAL_ENV-}" ]]; then
-            LP_VENV=" [${LP_COLOR_VIRTUALENV}${VIRTUAL_ENV##*/}${NO_COL}]"
+            if [[ "$LP_VIRTUALENV_PARENT" ]]; then
+                LP_VENV=" [${LP_COLOR_VIRTUALENV}$(basename $(dirname $VIRTUAL_ENV))${NO_COL}]"
+            else
+                LP_VENV=" [${LP_COLOR_VIRTUALENV}${VIRTUAL_ENV##*/}${NO_COL}]"
+            fi
         else
             LP_VENV=" [${LP_COLOR_VIRTUALENV}${CONDA_DEFAULT_ENV##*/}${NO_COL}]"
         fi

--- a/liquidpromptrc-dist
+++ b/liquidpromptrc-dist
@@ -120,6 +120,11 @@ LP_RUNTIME_THRESHOLD=2
 # Recommended value is 1
 LP_ENABLE_VIRTUALENV=1
 
+# Display virtualenv parent directory name, if you want to
+# create virtualenv inside your projects with standart name
+# like `venv`. Default value is 0.
+LP_VIRTUALENV_PARENT=0
+
 # Display the enabled software collections, if any
 # Recommended value is 1
 LP_ENABLE_SCLS=1


### PR DESCRIPTION
I'm always create virtualenv with name `venv` inside project. Also I used virtualenvs `--prompt` argument to specify name for my venv (because it `venv` in every project). But it doesn't work with liquidprompt because it rewrites PS1.

So I've added an option LP_VIRTUALENV_PARENT (default to 0). If enabled, liquidprompt will display venv parent dir name instead of fixed in my case.
