### PR TITLE
WIP - shorten directory relative to repo root

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -666,6 +666,32 @@ _lp_get_home_tilde_collapsed()
     echo "${PWD/#$HOME/$tilde}"
 }
 
+# Shorten the path of the current working directory by making it relative
+# to the VCS root, if in a VCS tracked directory
+# * Show directory name (as repo "name")
+# * Show the relative path from the root to "$PWD" in a different color
+_lp_shorten_vcs_path ()
+{
+    local root
+    case "$LP_VCS_TYPE" in
+        git*)   root="$(git rev-parse --show-toplevel)" ;;
+        hg)     root="$(hg root)" ;;
+        svn)    LANG=C root="$(svn info | grep 'Working Copy Root Path' | cut -d' ' -f5- | xargs)" ;;
+        bzr)    root="$(bzr root)" ;;
+        fossil) root="$(fossil status | grep local-root | cut -d' ' -f2- | xargs)" ;;
+    esac
+
+    # trim leading and trailing whitespace, as well as a potentially trailing slash
+    if [[ -n "$root" ]]; then
+        local name="${root##*/}"
+        local relpath="${${PWD#$root}%/}"
+        LP_PWD="${LP_COLOR_PATH_ROOT}$(_lp_escape "$name")$NO_COL"
+        LP_PWD="${LP_PWD}${LP_COLOR_PATH}$(_lp_escape "$relpath")$NO_COL"
+    else
+        _lp_shorten_path
+    fi
+}
+
 # Shorten the path of the current working directory
 # * Show only the current directory
 # * Show as much of the cwd path as possible, if shortened display a
@@ -1766,8 +1792,6 @@ _lp_set_prompt()
             fi
         fi
 
-        _lp_shorten_path   # set LP_PWD
-
         if _lp_are_vcs_enabled; then
             LP_VCS="$(_lp_git_branch_color)"
             LP_VCS_TYPE="git"
@@ -1814,6 +1838,12 @@ _lp_set_prompt()
 
         # end of the prompt line: double spaces
         LP_MARK="$(_lp_sr "$(_lp_smart_mark $LP_VCS_TYPE)")"
+
+        if [[ -n "$LP_VCS" ]]; then
+            _lp_shorten_vcs_path
+        else
+            _lp_shorten_path
+        fi
 
         LP_OLD_PWD="LP:$PWD"
 


### PR DESCRIPTION
demo: https://asciinema.org/a/21be5t92ib26uddrs9ehuaovr

I reported this as a feature request early last year: https://github.com/nojhan/liquidprompt/issues/349.
I have since brushed up on my shell skills and feel comfortable delivering the said feature set.

What's left to do?
- [x] show relative path when in **git** repo
- [x] show relative path when in **svn** repo
- [x] show relative path when in **hg** repo
- [x] show relative path when in **bzr** repo
- [x] show relative path when in **fossil** repo
- [ ] configure colouring of repo name (currently uses `$LP_COLOR_PATH_ROOT`) - **input required**
- [ ] toggle feature ON/OFF via option - **input required**
- [ ] how should this interact with the ordinary directory shortening? - **input required**

The way it's implemented it _should_ be easy to add support for the supported VCS systems, provided they have a way to get the top-level directory... otherwise we might half to walk the file system, but I hope not.

I'd say supporting submodules as mentioned in the original issue would be a separate PR, but I personally lost interest in that feature.
