### PR TITLE
_lp_color_map has output even if value exceeds scale

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -1394,6 +1394,9 @@ _lp_color_map() {
     scale=${2:-100}
     # Transform the value to a 0..${#COLOR_MAP} scale
     idx=_LP_FIRST_INDEX+100*$1/scale/${#LP_COLORMAP[*]}
+    if [[ "$idx" -ge "${#LP_COLORMAP[*]}" ]]; then
+        idx=-1
+    fi
     echo -nE "${LP_COLORMAP[idx]}"
 }
 


### PR DESCRIPTION
Notably with the load, no color is displayed by `_lp_color_map` when the value exceeds the provided scale. This PR fixes that by echoing the last item of the color map.
