### PR TITLE
Fixed battery status in MacOS X.

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -1299,7 +1299,7 @@ case "$LP_OS" in
     {
         (( LP_ENABLE_BATT )) || return 4
         local percent batt_status
-        eval "$(pmset -g batt | sed -n 's/^ -InternalBattery[^	 ]*[	 ]\([0-9]*[0-9]\)%; \([^;]*\).*$/percent=\1 batt_status='\'\\2\'/p)"
+        eval "$(pmset -g batt | sed -n 's/^ -InternalBattery.*[[:space:]]\([0-9]*[0-9]\)%; \([^;]*\).*$/percent=\1 batt_status='\'\\2\'/p)"
         case "$batt_status" in
             charged | "")
             return 4


### PR DESCRIPTION
Some time ago battery status under MacOS was broken due to changes in pmset output. In last MacOS X Sierra we have battery id an output of pmset looks like:
```
[thruhscat:~/develop/liquidprompt-thrushcat]↥ fix/macos-pmset 18s ± pmset -g batt
Now drawing from 'AC Power'
 -InternalBattery-0 (id=2228323)    100%; charged; 0:00 remaining present: true
```