### PR TITLE
Only calculate hash for ssh host color if option is enabled

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -286,11 +286,13 @@ _lp_source_config()
     # NO_COL is special: it will be used at runtime, not just during config loading
     NO_COL="${_LP_OPEN_ESC}${ti_sgr0}${_LP_CLOSE_ESC}"
 
-    # compute the hash of the hostname
-    # and get the corresponding number in [1-6] (red,green,yellow,blue,purple or cyan)
-    # FIXME check portability of cksum and add more formats (bold? 256 colors?)
-    local hash=$(( 1 + $(hostname | cksum | cut -d " " -f 1) % 6 ))
-    LP_COLOR_HOST_HASH="${_LP_OPEN_ESC}$(ti_setaf $hash)${_LP_CLOSE_ESC}"
+    if (( LP_ENABLE_SSH_COLORS )); then
+        # compute the hash of the hostname
+        # and get the corresponding number in [1-6] (red,green,yellow,blue,purple or cyan)
+        # FIXME check portability of cksum and add more formats (bold? 256 colors?)
+        local hash=$(( 1 + $(hostname | cksum | cut -d " " -f 1) % 6 ))
+        LP_COLOR_HOST_HASH="${_LP_OPEN_ESC}$(ti_setaf $hash)${_LP_CLOSE_ESC}"
+    fi
 
     unset ti_sgr0 ti_bold
     unset -f ti_setaf ti_setab


### PR DESCRIPTION
Only calculate hash for ssh host color if option LP_ENABLE_SSH_COLORS is enabled.
