### PR TITLE
Replace awk with sed for speed and remove a comma

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -201,7 +201,7 @@ case "$LP_OS" in
         ;;
     SunOS)
         _lp_cpu_load () {
-            read lp_cpu_load <<<"$( LANG=C uptime | awk '{print substr($10,0,length($10))}' )"
+            read lp_cpu_load <<<"$( LANG=C uptime | sed 's/.*load average: *\([0-9.]*\).*/\1/' )"
         }
 esac
 


### PR DESCRIPTION
Fix for #479 

The SunOS CPU load check was returning with a comma, which would cause a
math operation to fail. Replacing the `awk` command with a `sed` one with more ambiguity should prevent problems like this in the future.