### PR TITLE
Add nodeenv virtual environment support

### DIFF
--- a/liquid.ps1
+++ b/liquid.ps1
@@ -12,6 +12,7 @@
 # LP_PERM a colon ":"
 # LP_PWD current working directory
 # LP_VENV Python virtual environment
+# LP_NODEENV Nodeenv virtual environment
 # LP_PROXY HTTP proxy
 # LP_VCS the content of the current repository
 # LP_ERR last error code
@@ -33,7 +34,7 @@ LP_PS1="${LP_PS1_PREFIX}${LP_TIME}${LP_BATT}${LP_LOAD}${LP_JOBS}"
 # add user, host and permissions colon
 LP_PS1="${LP_PS1}${LP_BRACKET_OPEN}${LP_USER}${LP_HOST}${LP_PERM}"
 
-LP_PS1="${LP_PS1}${LP_PWD}${LP_BRACKET_CLOSE}${LP_VENV}${LP_PROXY}"
+LP_PS1="${LP_PS1}${LP_PWD}${LP_BRACKET_CLOSE}${LP_VENV}${LP_NODEENV}${LP_PROXY}"
 
 # Add VCS infos
 # If root, the info has not been collected unless LP_ENABLE_VCS_ROOT

--- a/liquid.theme
+++ b/liquid.theme
@@ -116,6 +116,9 @@ LP_COLOR_IN_MULTIPLEXER="$BOLD_BLUE"
 # Virtual environment
 LP_COLOR_VIRTUALENV="$CYAN"
 
+# Nodeenv virtual environment
+LP_COLOR_NODEENV="$LP_COLOR_VIRTUALENV"
+
 # Runtime
 LP_COLOR_RUNTIME="$YELLOW"
 

--- a/liquidprompt
+++ b/liquidprompt
@@ -328,6 +328,7 @@ _lp_source_config()
     LP_ENABLE_TIME=${LP_ENABLE_TIME:-0}
     LP_ENABLE_RUNTIME=${LP_ENABLE_RUNTIME:-1}
     LP_ENABLE_VIRTUALENV=${LP_ENABLE_VIRTUALENV:-1}
+    LP_ENABLE_NODEENV=${LP_ENABLE_NODEENV:-1}
     LP_ENABLE_SCLS=${LP_ENABLE_SCLS:-1}
     LP_ENABLE_VCS_ROOT=${LP_ENABLE_VCS_ROOT:-0}
     LP_ENABLE_TITLE=${LP_ENABLE_TITLE:-0}
@@ -392,6 +393,7 @@ _lp_source_config()
     LP_COLOR_IN_MULTIPLEXER=${LP_COLOR_IN_MULTIPLEXER:-$BOLD_BLUE}
     LP_COLOR_RUNTIME=${LP_COLOR_RUNTIME:-$YELLOW}
     LP_COLOR_VIRTUALENV=${LP_COLOR_VIRTUALENV:-$CYAN}
+    LP_COLOR_NODEENV=${LO_COLOR_NODEENV:-$LP_COLOR_VIRTUALENV}
 
     if [[ -z "${LP_COLORMAP-}" ]]; then
         LP_COLORMAP=(
@@ -1739,6 +1741,13 @@ _lp_set_prompt()
         LP_VENV=
     fi
 
+    # Display the current nodeenv virtual environment, if available
+    if [[ "$LP_ENABLE_NODEENV,${NODE_VIRTUAL_ENV-}" = 1,?* ]]; then
+        LP_NODEENV=" [${LP_COLOR_NODEENV}${NODE_VIRTUAL_ENV##*/}${NO_COL}]"
+    else
+        LP_NODEENV=
+    fi
+
     # Display the current software collections enabled, if available
     if [[ "$LP_ENABLE_SCLS,${X_SCLS-}" = 1,?* ]]; then
         LP_SCLS=" [${LP_COLOR_VIRTUALENV}${X_SCLS%"${X_SCLS##*[![:space:]]}"}${NO_COL}]"
@@ -1843,7 +1852,7 @@ _lp_set_prompt()
         # add user, host and permissions colon
         PS1+="${LP_BRACKET_OPEN}${LP_USER}${LP_HOST}${LP_PERM}"
 
-        PS1+="${LP_PWD}${LP_BRACKET_CLOSE}${LP_SCLS}${LP_VENV}${LP_PROXY}"
+        PS1+="${LP_PWD}${LP_BRACKET_CLOSE}${LP_SCLS}${LP_VENV}${LP_NODEENV}${LP_PROXY}"
 
         # Add VCS infos
         # If root, the info has not been collected unless LP_ENABLE_VCS_ROOT

--- a/liquidpromptrc-dist
+++ b/liquidpromptrc-dist
@@ -130,6 +130,10 @@ LP_RUNTIME_THRESHOLD=2
 # Recommended value is 1
 LP_ENABLE_VIRTUALENV=1
 
+# Display de nodeenv virtual that is currently activated, if any
+# Recommended value is 1
+LP_ENABLE_NODEENV=1
+
 # Display the enabled software collections, if any
 # Recommended value is 1
 LP_ENABLE_SCLS=1


### PR DESCRIPTION
[Nodeenv](https://github.com/ekalinin/nodeenv) is a tool for Node.js equivalent to virtualenv for Python, it allow to create Node.js virtual environments.

This commit add support for showing the nodeenv virtual environment activated, if any.

Configuration:
* `LP_ENABLE_NODEENV` activate (1) or deactivate (0) the feature; by default 1.
* `LP_COLOR_NODEENV` set the virtual environment name color; by default `LP_COLOR_VIRTUALENV` (the setting for the Python virtual environment color).