### PR TITLE
Add support for AWS_PROFILE and AWS_DEFAULT_PROFILE environment variables

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -228,6 +228,20 @@ Features
 
    See also: :attr:`LP_MARK_DISABLED`.
 
+.. attribute:: LP_ENABLE_AWS_PROFILE
+   :type: bool
+   :value: 1
+
+   Display the current value of :envvar:`AWS_PROFILE` or 
+   :envvar:`AWS_DEFAULT_PROFILE`. These variables are used to switch between
+   configuration profiles by the `AWS CLI`_.
+
+   .. _`AWS CLI`: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html
+
+   See also: :attr:`LP_COLOR_AWS_PROFILE`.
+
+   .. versionadded:: 2.1
+
 .. attribute:: LP_ENABLE_BATT
    :type: bool
    :value: 1
@@ -889,6 +903,16 @@ Valid preset color variables are:
 
    See also: :attr:`LP_ENABLE_BATT`, :attr:`LP_ENABLE_LOAD`, and
    :attr:`LP_ENABLE_TEMP`.
+
+.. attribute:: LP_COLOR_AWS_PROFILE
+   :type: string
+   :value: $YELLOW
+
+   Color used to display the current active AWS Profile.
+
+   See also: :attr:`LP_ENABLE_AWS_PROFILE`.
+
+   .. versionadded:: 2.1
 
 .. attribute:: LP_COLOR_CHANGES
    :type: string

--- a/docs/functions/data.rst
+++ b/docs/functions/data.rst
@@ -86,6 +86,16 @@ Development Environment
 Environment
 -----------
 
+.. function:: _lp_aws_profile() -> var:lp_aws_profile
+
+   Returns ``true`` if the :envvar:`AWS_PROFILE` or :envvar:`AWS_DEFAULT_PROFILE`
+   variables are found in the environment (in that order of preference).
+   Returns the contents of the variable.
+
+   Can be disabled by :attr:`LP_ENABLE_AWS_PROFILE`.
+
+   .. versionadded:: 2.1
+
 .. function:: _lp_connected_display()
 
    Returns ``true`` if there is a connected X11 display.

--- a/docs/functions/theme.rst
+++ b/docs/functions/theme.rst
@@ -90,6 +90,12 @@ specific text and formatting may change.
 
    .. versionadded:: 2.0
 
+.. function:: _lp_aws_profile_color() -> var:lp_aws_profile_color
+
+   Returns :func:`_lp_aws_profile` with color from :attr:`LP_COLOR_AWS_PROFILE`.
+
+   .. versionadded:: 2.1
+
 .. function:: _lp_battery_color() -> var:lp_battery_color
 
    Returns data from :func:`_lp_battery`, colored with:

--- a/docs/theme/default.rst
+++ b/docs/theme/default.rst
@@ -175,6 +175,13 @@ default order if the user does not configure a different template.
    The current Red Hat Software Collections environment. See
    :attr:`LP_ENABLE_SCLS`.
 
+.. attribute:: LP_AWS_PROFILE
+
+   The current active AWS Profile. See
+   :attr:`LP_ENABLE_AWS_PROFILE`.
+
+   .. versionadded:: 2.1
+
 .. attribute:: LP_VENV
 
    The current Python (or Conda) virtual environment. See

--- a/liquidprompt
+++ b/liquidprompt
@@ -216,6 +216,7 @@ __lp_source_config() {
     LP_ENABLE_RUNTIME_BELL=${LP_ENABLE_RUNTIME_BELL:-0}
     LP_ENABLE_VIRTUALENV=${LP_ENABLE_VIRTUALENV:-1}
     LP_ENABLE_SCLS=${LP_ENABLE_SCLS:-1}
+    LP_ENABLE_AWS_PROFILE=${LP_ENABLE_AWS_PROFILE:-1}
     LP_ENABLE_VCS_ROOT=${LP_ENABLE_VCS_ROOT:-0}
     LP_ENABLE_TITLE=${LP_ENABLE_TITLE:-0}
     LP_ENABLE_SCREEN_TITLE=${LP_ENABLE_SCREEN_TITLE:-0}
@@ -292,6 +293,7 @@ __lp_source_config() {
     LP_COLOR_VIRTUALENV=${LP_COLOR_VIRTUALENV:-$CYAN}
     LP_COLOR_DIRSTACK=${LP_COLOR_DIRSTACK:-$BOLD_YELLOW}
     LP_COLOR_KUBECONTEXT=${LP_COLOR_KUBECONTEXT:-$CYAN}
+    LP_COLOR_AWS_PROFILE=${LP_COLOR_AWS_PROFILE:-$YELLOW}
 
     if [[ -z "${LP_COLORMAP-}" ]]; then
         LP_COLORMAP=(
@@ -1314,6 +1316,26 @@ _lp_dirstack_color() {
     _lp_dirstack || return "$?"
 
     lp_dirstack_color="${LP_COLOR_DIRSTACK}${LP_MARK_DIRSTACK}${lp_dirstack}${NO_COL}"
+}
+
+_lp_aws_profile() {
+    (( LP_ENABLE_AWS_PROFILE )) || return 2
+
+    local ret
+
+    local aws_profile="${AWS_PROFILE-${AWS_DEFAULT_PROFILE-}}"
+    if [[ -n $aws_profile ]]; then
+        __lp_escape "${aws_profile}"
+        lp_aws_profile=$ret
+    else
+        return 1
+    fi
+}
+
+_lp_aws_profile_color() {
+    _lp_aws_profile || return "$?"
+
+    lp_aws_profile_color="[${LP_COLOR_AWS_PROFILE}${lp_aws_profile}${NO_COL}]"
 }
 
 ################
@@ -2735,6 +2757,12 @@ _lp_default_theme_prompt_data() {
         LP_SCLS=
     fi
 
+    if _lp_aws_profile_color; then
+        LP_AWS_PROFILE=" $lp_aws_profile_color"
+    else
+        LP_AWS_PROFILE=
+    fi
+
     if _lp_runtime_color; then
         LP_RUNTIME=" $lp_runtime_color"
     else
@@ -2768,7 +2796,7 @@ _lp_default_theme_prompt_template() {
         # add user, host and permissions colon
         PS1+="${LP_BRACKET_OPEN}${LP_USER}${LP_HOST}${LP_PERM}"
 
-        PS1+="${LP_PWD}${LP_DIRSTACK}${LP_BRACKET_CLOSE}${LP_SCLS}${LP_VENV}${LP_KUBECONTEXT}${LP_PROXY}"
+        PS1+="${LP_PWD}${LP_DIRSTACK}${LP_BRACKET_CLOSE}${LP_SCLS}${LP_AWS_PROFILE}${LP_VENV}${LP_KUBECONTEXT}${LP_PROXY}"
 
         # Add VCS infos
         # If root, the info has not been collected unless LP_ENABLE_VCS_ROOT

--- a/liquidpromptrc-dist
+++ b/liquidpromptrc-dist
@@ -162,6 +162,10 @@ LP_ENABLE_KUBECONTEXT=0
 # in order to output "dev" and "test" in prompt.
 LP_DELIMITER_KUBECONTEXT=
 
+# Display the current active AWS_PROFILE, if any
+# Recommended value is 1
+LP_ENABLE_AWS_PROFILE=1
+
 # Show highest system temperature
 LP_ENABLE_TEMP=1
 


### PR DESCRIPTION
This is useful when working with multiple AWS accounts over the API or CLI. This simple addition will ensure `AWS_DEFAULT_PROFILE` is displayed if set.