### PR TITLE
Use fossil branch list instead of status to get branch name

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -1115,11 +1115,11 @@ _lp_fossil_branch()
 {
     (( LP_ENABLE_FOSSIL )) || return
     local branch
-    branch=$(fossil status 2>/dev/null | sed -n -$_LP_SED_EXTENDED 's/^tags:\s+(\w*)$/\1/p')
+    branch=$(fossil branch list 2>/dev/null | sed -n -$_LP_SED_EXTENDED 's/^\*\s+(\w*)$/\1/p')
     if [[ -n "$branch" ]]; then
         echo -nE "$branch"
     elif fossil info &>/dev/null ; then
-        echo -n "no-tag"
+        echo -n "no-branch"
     fi
 }
 


### PR DESCRIPTION
It's more efficient and avoid a lot of wrong branch detection due to tag mismatch.