### PR TITLE
Optimize the git command used to check stash

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -896,7 +896,7 @@ _lp_git_branch_color()
             end="$LP_COLOR_CHANGES$LP_MARK_UNTRACKED$end"
         fi
 
-        if [[ -n "$(\git stash list -n 1 2>/dev/null)" ]]; then
+        if [[ -n "$(\git rev-parse refs/stash 2>/dev/null | grep -v 'refs/stash')" ]]; then
             end="$LP_COLOR_COMMITS$LP_MARK_STASH$end"
         fi
 


### PR DESCRIPTION
Compare the output of `GIT_TRACE=1 git rev-parse refs/stash`
with `GIT_TRACE=1 git stash list -n 1`. Both return the most recent
saved stash, but rev-parse takes less time and fewer calls.

When there is no saved stash, rev-parse will return 'refs/stash',
so we need to filter that out.