### PR TITLE
Remove -E from grep in git untracked check

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -892,7 +892,7 @@ _lp_git_branch_color()
         local end
         end="${LP_COLOR_CHANGES}$(_lp_git_head_status)${NO_COL}"
 
-        if LC_ALL=C \git status --porcelain 2>/dev/null | \grep -Eq '^\?\?'; then
+        if LC_ALL=C \git status --porcelain 2>/dev/null | \grep -q '^\?\?'; then
             end="$LP_COLOR_CHANGES$LP_MARK_UNTRACKED$end"
         fi
 


### PR DESCRIPTION
Non GNU versions of grep don't always support -E. In this case, it added
nothing to the command, so it is safe (and probably faster) to remove.

There is another location, on line 553, where grep -E is used, but it is
for the sudo check, so it is used less often.

Fix for #504 