### PR TITLE
fixing bad regex on file tracking in two VCS (git and hg)

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -892,7 +892,7 @@ _lp_git_branch_color()
         local end
         end="${LP_COLOR_CHANGES}$(_lp_git_head_status)${NO_COL}"
 
-        if LC_ALL=C \git status --porcelain 2>/dev/null | \grep -q '^\?\?'; then
+        if LC_ALL=C \git status --porcelain 2>/dev/null | \grep -q '^??'; then
             end="$LP_COLOR_CHANGES$LP_MARK_UNTRACKED$end"
         fi
 
@@ -1020,7 +1020,7 @@ _lp_hg_branch_color()
 
         local has_untracked
         has_untracked=
-        if hg status -u 2>/dev/null | \grep -q '^\?' >/dev/null ; then
+        if hg status -u 2>/dev/null | \grep -q '^?' >/dev/null ; then
             has_untracked="$LP_COLOR_CHANGES$LP_MARK_UNTRACKED"
         fi
 


### PR DESCRIPTION
untracked flag is showing as soon as modification has been made (as soon as git status --porcelain show something)

This fix should solve this for both git and mercurial