### PR TITLE
Allow liquidpromptrc in ~/.config/liquidprompt/

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -430,6 +430,9 @@ _lp_source_config()
             if [[ -f "$first/liquidpromptrc" ]]; then
                 configfile="$first/liquidpromptrc"
                 break
+            elif [[ -f "$first/liquidprompt/liquidpromptrc" ]]; then
+                configfile="$first/liquidprompt/liquidpromptrc"
+                break
             fi
         done
     fi


### PR DESCRIPTION
This feature allows to put liquidpromptrc in the ~/.config/liquidprompt/ directory. We then can have all configuration files (rc, .theme, .PS1) in one unique directory called "liquidprompt" under ~/.config/.

This is my first pull request in Github, I hope I've made everything correctly.