### PR TITLE
Remove extra newline for LP_ENABLE_TITLE

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -1590,7 +1590,8 @@ _lp_as_text()
 {
     # Remove all terminal sequences that we wrapped with $_LP_OPEN_ESC and
     # $_LP_CLOSE_ESC.
-    echo -nE "$1" | sed -$_LP_SED_EXTENDED "s,$_LP_CLEAN_ESC,,g"
+    # chomp trailing newline, which is emitted by sed on macOS
+    echo -nE "$1" | sed -$_LP_SED_EXTENDED "s,$_LP_CLEAN_ESC,,g" | tr -d '\n'
 }
 
 _lp_title()


### PR DESCRIPTION
This fixes an extra newline that appears before the prompt when `LP_ENABLE_TITLE` is set to `1` on macOS.  This results in output like

```
[:~] $ date
Tue Apr 18 15:21:36 EDT 2017

[:~] $ 
```

when the desired result is

```
[:~] $ date
Tue Apr 18 15:21:36 EDT 2017
[:~] $ 
```

Alternative implementation would be to redefine `_lp_title` as

    echo -nE "${_LP_OPEN_ESC}${LP_TITLE_OPEN}$( _lp_as_text "$1" )${LP_TITLE_CLOSE}${_LP_CLOSE_ESC}"