### PR TITLE
Supressing sensors errors

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -1511,7 +1511,7 @@ if (( LP_ENABLE_TEMP )); then
         # Return the hottest system temperature we get through the sensors command
         # Only the integer part is retained
         local -i i
-        for i in $(sensors -u |
+        for i in $(sensors -u 2>/dev/null |
                 sed -n 's/^  temp[0-9][0-9]*_input: \([0-9]*\)\..*$/\1/p'); do
             (( $i > ${temperature:-0} )) && temperature=i
         done


### PR DESCRIPTION
This patch supress reading errors related to "sensors -u" (with raw data) when using buggy GPU drivers (nvidia & ATI)

It applies the solution presented by Rmano on Issue #445 
