### PR TITLE
Fixed battery reporting

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -1314,7 +1314,7 @@ case "$LP_OS" in
             *)  # "charging", "AC attached"
                 echo -nE "$percent"
                 # under => 2, above => 3
-                return $(( 1 + ( percent > LP_BATTERY_THRESHOLD ) ))
+                return $(( 2 + ( percent > LP_BATTERY_THRESHOLD ) ))
             ;;
         esac
     }

--- a/liquidprompt
+++ b/liquidprompt
@@ -1301,7 +1301,7 @@ case "$LP_OS" in
     {
         (( LP_ENABLE_BATT )) || return 4
         local percent batt_status
-        eval "$(pmset -g batt | sed -n 's/^ -InternalBattery[^	 ]*[	 ]\([0-9]*[0-9]\)%; \([^;]*\).*$/percent=\1 batt_status='\'\\2\'/p)"
+        eval "$(pmset -g batt | awk '/InternalBattery/{gsub(/[^0-9]/,"",$3);gsub(/[;]/,"",$4);printf "percent=%d batt_status=%s", $3, $4}')"
         case "$batt_status" in
             charged | "")
             return 4


### PR DESCRIPTION
The sed script was having some issues with the way `pmset -g batt` output looks on macOS 10.12 Sierra and later. I rewrote the sed commands to an awk script, which is a bit more resistant to any future format changes.