### PR TITLE
Explain unofficial work around for PROMPT_COMMAND

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,9 @@ You can even theme Liquid Prompt and use a custom PS1 prompt. This is explained
 in the sections below.
 
 Check in your `.bashrc` that the `PROMPT_COMMAND` variable is not set, or else
-the prompt will not be available.
+the prompt will not be available. If you must set it or use a add-on that sets
+it, make sure to set `PROMPT_COMMAND` before you source Liquid Prompt to avoid
+history and timing issues. Do not export `PROMPT_COMMAND`.
 
 ### Installation via Antigen
 


### PR DESCRIPTION
Since there have been so many issues with people setting `PROMPT_COMMAND`
when they shouldn't, add the official explanation of the unofficial
work around to be able to set it and still get the prompt to work.

List of issues where this was at least part of the solution:
#276
#352
#436
#450
#463
#481
#516