### PR TITLE
_lp_connection: correctly detect local connection if X11 display doesn't start with colon

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -595,7 +595,7 @@ _lp_connection()
         # TODO check on *BSD
         local whoami="$(LC_ALL=C who am i)"
         local sess_parent="$(ps -o comm= -p $PPID 2> /dev/null)"
-        if [[ x"$whoami" != *'('* || x"$whoami" = *'(:'* || x"$whoami" = *'(tmux'* ]]; then
+        if [[ x"$whoami" != *'('* || x"$whoami" = *'(:'* || ( -n "${DISPLAY-}" && x"$whoami" = *"(${DISPLAY-})" ) || x"$whoami" = *'(tmux'* ]]; then
             echo lcl  # Local
         elif [[ "$sess_parent" = "su" || "$sess_parent" = "sudo" ]]; then
             echo su   # Remote su/sudo


### PR DESCRIPTION
FreeBSD with slim display manager sets `DISPLAY=unix:0.0`, which is
currently detected as telnet session and displayed in ugly red.

```
[japhy:~] % who am i
japhy            pts/3        28 Aug 16:36 (unix:0.0)
[japhy:~] % echo $DISPLAY
unix:0.0
[japhy:~] % uname -a
FreeBSD sophon.local 12.0-CURRENT FreeBSD 12.0-CURRENT #0 r333486: Fri May 11 12:32:05 UTC 2018     maciej@hatter:/usr/obj/usr/src/amd64.amd64/sys/GENERIC-NODEBUG  amd64
```

It's quite likely that this renders the previous condition (`x"$whoami" = *'(:'*`) redundant, but I didn't want to remove it without confirmation.