### PR TITLE
Display selected node.js version if using NVM

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -328,6 +328,7 @@ _lp_source_config()
     LP_ENABLE_TIME=${LP_ENABLE_TIME:-0}
     LP_ENABLE_RUNTIME=${LP_ENABLE_RUNTIME:-1}
     LP_ENABLE_VIRTUALENV=${LP_ENABLE_VIRTUALENV:-1}
+    LP_ENABLE_NVM=${LP_ENABLE_NVM:-1}
     LP_ENABLE_SCLS=${LP_ENABLE_SCLS:-1}
     LP_ENABLE_VCS_ROOT=${LP_ENABLE_VCS_ROOT:-0}
     LP_ENABLE_TITLE=${LP_ENABLE_TITLE:-0}
@@ -392,6 +393,7 @@ _lp_source_config()
     LP_COLOR_IN_MULTIPLEXER=${LP_COLOR_IN_MULTIPLEXER:-$BOLD_BLUE}
     LP_COLOR_RUNTIME=${LP_COLOR_RUNTIME:-$YELLOW}
     LP_COLOR_VIRTUALENV=${LP_COLOR_VIRTUALENV:-$CYAN}
+    LP_COLOR_NVM=${LP_COLOR_NVM:-$CYAN}
 
     if [[ -z "${LP_COLORMAP-}" ]]; then
         LP_COLORMAP=(
@@ -1740,6 +1742,14 @@ _lp_set_prompt()
         LP_VENV=
     fi
 
+    # Display the current NVM selection, if available
+    if [[ "$LP_ENABLE_NVM,${NVM_BIN-}" = 1,?* ]]; then
+        LP_NVM="${NVM_BIN##*node/v}"
+        LP_NVM=" [${LP_COLOR_NVM}node-${LP_NVM%/bin}${NO_COL}]"
+    else
+        LP_NVM=
+    fi
+
     # Display the current software collections enabled, if available
     if [[ "$LP_ENABLE_SCLS,${X_SCLS-}" = 1,?* ]]; then
         LP_SCLS=" [${LP_COLOR_VIRTUALENV}${X_SCLS%"${X_SCLS##*[![:space:]]}"}${NO_COL}]"
@@ -1844,7 +1854,7 @@ _lp_set_prompt()
         # add user, host and permissions colon
         PS1+="${LP_BRACKET_OPEN}${LP_USER}${LP_HOST}${LP_PERM}"
 
-        PS1+="${LP_PWD}${LP_BRACKET_CLOSE}${LP_SCLS}${LP_VENV}${LP_PROXY}"
+        PS1+="${LP_PWD}${LP_BRACKET_CLOSE}${LP_SCLS}${LP_VENV}${LP_NVM}${LP_PROXY}"
 
         # Add VCS infos
         # If root, the info has not been collected unless LP_ENABLE_VCS_ROOT

--- a/liquidpromptrc-dist
+++ b/liquidpromptrc-dist
@@ -130,6 +130,10 @@ LP_RUNTIME_THRESHOLD=2
 # Recommended value is 1
 LP_ENABLE_VIRTUALENV=1
 
+# Display Node version that is currently selected with NVM, if any
+# Recommended value is 1
+LP_ENABLE_NVM=1
+
 # Display the enabled software collections, if any
 # Recommended value is 1
 LP_ENABLE_SCLS=1


### PR DESCRIPTION
This patch enables displaying the currently selected node.js version,
set by [NVM]. Implementation follows the python virtualenv display
setting.

![nvm-liquidprompt](https://user-images.githubusercontent.com/6640417/50539853-510bf100-0b7f-11e9-88ed-3fbb78454df6.png)

[NVM]: https://github.com/creationix/nvm