### PR TITLE
Add tag to git branch information

### DIFF
--- a/liquid.theme
+++ b/liquid.theme
@@ -24,6 +24,7 @@ if [[ "$(locale -k LC_CTYPE | sed -n 's/^charmap="\(.*\)"/\1/p')" == *"UTF-8"* ]
     LP_MARK_STASH="+"          # if git has stashs
     LP_MARK_SHORTEN_PATH=" … " # prompt mark in shortened paths
     LP_MARK_PERM=":"           # separator between host and path
+    LP_MARK_VCS_TAG="⚑"        # separator between branch and tag
 else
     # If charset is anything else, fallback to ASCII chars
     LP_MARK_BATTERY="b"
@@ -40,6 +41,7 @@ else
     LP_MARK_STASH="+"
     LP_MARK_SHORTEN_PATH=" ... "
     LP_MARK_PERM=":"
+    LP_MARK_VCS_TAG="^"
 fi
 
 LP_MARK_BRACKET_OPEN="["  # open bracket

--- a/liquidprompt
+++ b/liquidprompt
@@ -848,15 +848,18 @@ _lp_git_branch()
 
     \git rev-parse --is-inside-work-tree >/dev/null 2>&1 || return
 
-    local branch
+    local branch tag
+    if tag="$(\git describe --exact-match --tags 2>/dev/null)"; then
+        tag="($tag)"
+    fi
     # Recent versions of Git support the --short option for symbolic-ref, but
     # not 1.7.9 (Ubuntu 12.04)
     if branch="$(\git symbolic-ref -q HEAD)"; then
-        _lp_escape "${branch#refs/heads/}"
+        _lp_escape "${branch#refs/heads/}$tag"
     else
         # In detached head state, use commit instead
         # No escape needed
-        \git rev-parse --short -q HEAD
+        _lp_escape "$(\git rev-parse --short -q HEAD)$tag"
     fi
 }
 

--- a/liquidprompt
+++ b/liquidprompt
@@ -853,11 +853,11 @@ _lp_git_branch()
     # Recent versions of Git support the --short option for symbolic-ref, but
     # not 1.7.9 (Ubuntu 12.04)
     if branch="$(\git symbolic-ref -q HEAD)"; then
-        _lp_escape "${branch#refs/heads/}$tag"
+        _lp_escape "${branch#refs/heads/}"
     else
         # In detached head state, use commit instead
         # No escape needed
-        _lp_escape "$(\git rev-parse --short -q HEAD)$tag"
+        \git rev-parse --short -q HEAD
     fi
 }
 
@@ -931,7 +931,7 @@ _lp_git_branch_color()
 
         local tag
         if tag="$(\git describe --exact-match --tags 2>/dev/null)"; then
-            branch="${branch}$LP_MARK_VCS_TAG$tag"
+            branch="${branch}$LP_MARK_VCS_TAG$(_lp_escape "$tag")"
         fi
 
         if [[ -n "$shortstat" ]]; then

--- a/liquidprompt
+++ b/liquidprompt
@@ -357,6 +357,7 @@ _lp_source_config()
     LP_MARK_SHORTEN_PATH="${LP_MARK_SHORTEN_PATH:-" … "}"
     LP_MARK_PREFIX="${LP_MARK_PREFIX:-" "}"
     LP_MARK_PERM="${LP_MARK_PERM:-":"}"
+    LP_MARK_VCS_TAG="${LP_MARK_VCS_TAG:-"⚑"}"
 
     LP_COLOR_PATH=${LP_COLOR_PATH:-$BOLD}
     LP_COLOR_PATH_ROOT=${LP_COLOR_PATH_ROOT:-$BOLD_YELLOW}
@@ -850,7 +851,7 @@ _lp_git_branch()
 
     local branch tag
     if tag="$(\git describe --exact-match --tags 2>/dev/null)"; then
-        tag="($tag)"
+        tag="$LP_MARK_VCS_TAG$tag"
     fi
     # Recent versions of Git support the --short option for symbolic-ref, but
     # not 1.7.9 (Ubuntu 12.04)

--- a/liquidprompt
+++ b/liquidprompt
@@ -849,10 +849,7 @@ _lp_git_branch()
 
     \git rev-parse --is-inside-work-tree >/dev/null 2>&1 || return
 
-    local branch tag
-    if tag="$(\git describe --exact-match --tags 2>/dev/null)"; then
-        tag="$LP_MARK_VCS_TAG$tag"
-    fi
+    local branch
     # Recent versions of Git support the --short option for symbolic-ref, but
     # not 1.7.9 (Ubuntu 12.04)
     if branch="$(\git symbolic-ref -q HEAD)"; then
@@ -931,6 +928,11 @@ _lp_git_branch_color()
         local ret
         local shortstat # only to check for uncommitted changes
         shortstat="$(LC_ALL=C \git diff --shortstat HEAD 2>/dev/null)"
+
+        local tag
+        if tag="$(\git describe --exact-match --tags 2>/dev/null)"; then
+            branch="${branch}$LP_MARK_VCS_TAG$tag"
+        fi
 
         if [[ -n "$shortstat" ]]; then
             local u_stat # shorstat of *unstaged* changes


### PR DESCRIPTION
Add tag information if exact matches current HEAD.

```
# show branch - HEAD has no tag
develop+* ± git co master
# show branch - HEAD has tag
master⚑rel14.3+* 1 ± git co rel14.2
# detached tag
d46151ed⚑rel14.2+* ± git co 9d899
# detached
9d899338+* ±
```