### PR TITLE
Add LP_RUNTIME_BELL to ring bell for slow commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ You can configure some variables in the `~/.config/liquidpromptrc` file:
 * `LP_LOAD_THRESHOLD`, the minimal value after which the load average is displayed
 * `LP_TEMP_THRESHOLD`, the minimal value after which the average temperature is displayed
 * `LP_RUNTIME_THRESHOLD`, the minimal value after which the runtime is displayed
+*  LP_RUNTIME_BELL , ring the bell when LP_RUNTIME_THRESHOLD is exceeded.
 * `LP_PATH_LENGTH`, the maximum percentage of the screen width used to display the path
 * `LP_PATH_KEEP`, how many directories to keep at the beginning of a shortened path
 * `LP_HOSTNAME_ALWAYS`, a choice between always displaying the hostname or

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ You can configure some variables in the `~/.config/liquidpromptrc` file:
 * `LP_LOAD_THRESHOLD`, the minimal value after which the load average is displayed
 * `LP_TEMP_THRESHOLD`, the minimal value after which the average temperature is displayed
 * `LP_RUNTIME_THRESHOLD`, the minimal value after which the runtime is displayed
-*  LP_RUNTIME_BELL , ring the bell when LP_RUNTIME_THRESHOLD is exceeded.
+* `LP_RUNTIME_BELL_THRESHOLD`, the minimal value after which the bell is rung.
 * `LP_PATH_LENGTH`, the maximum percentage of the screen width used to display the path
 * `LP_PATH_KEEP`, how many directories to keep at the beginning of a shortened path
 * `LP_HOSTNAME_ALWAYS`, a choice between always displaying the hostname or
@@ -174,6 +174,7 @@ prompt-building process:
 * `LP_ENABLE_SCREEN_TITLE`, if you want to use the prompt as your screen window's title
 * `LP_ENABLE_SSH_COLORS`, if you want different colors for hosts you SSH into
 * `LP_ENABLE_RUNTIME`, if you want to display the runtime of the last command
+* `LP_ENABLE_RUNTIME_BELL`, if you want to ring the bell when a runtime threshold is exceeded.
 * `LP_ENABLE_SUDO`, if you want the prompt mark to change color while you have password-less root access
 * `LP_ENABLE_FQDN`, if you want the display of the fully qualified domain name
 * `LP_ENABLE_TIME`, if you want to display the time at which the prompt was shown

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ You can configure some variables in the `~/.config/liquidpromptrc` file:
 * `LP_LOAD_THRESHOLD`, the minimal value after which the load average is displayed
 * `LP_TEMP_THRESHOLD`, the minimal value after which the average temperature is displayed
 * `LP_RUNTIME_THRESHOLD`, the minimal value after which the runtime is displayed
-* `LP_RUNTIME_BELL_THRESHOLD`, the minimal value after which the bell is rung.
+* `LP_RUNTIME_BELL_THRESHOLD`, the minimal value after which the bell is rung. See LP_ENABLE_RUNTIME_BELL.
 * `LP_PATH_LENGTH`, the maximum percentage of the screen width used to display the path
 * `LP_PATH_KEEP`, how many directories to keep at the beginning of a shortened path
 * `LP_HOSTNAME_ALWAYS`, a choice between always displaying the hostname or

--- a/liquidprompt
+++ b/liquidprompt
@@ -1422,7 +1422,9 @@ _lp_runtime()
         # if enabled, ring the bell
         if (( LP_RUNTIME_BELL ))
         then
-            tput bel
+            #bash reprints $PS1 on every SIGWINCH, so we tput to stderr here so the bell is not
+            #captured in PS1.  This way the bell only rings once, not on every terminal resize.
+            tput bel >&2
         fi
     fi
     :

--- a/liquidprompt
+++ b/liquidprompt
@@ -1425,7 +1425,7 @@ _lp_runtime()
     then
         #bash reprints $PS1 on every SIGWINCH, so we tput to stderr here so the bell is not
         #captured in PS1.  This way the bell only rings once, not on every terminal resize.
-        tput bel >&2
+        { tput bel || tput bl ; } >&2 2>/dev/null
     fi
     :
 }

--- a/liquidprompt
+++ b/liquidprompt
@@ -302,7 +302,7 @@ _lp_source_config()
     LP_LOAD_THRESHOLD=${LP_LOAD_THRESHOLD:-60}
     LP_TEMP_THRESHOLD=${LP_TEMP_THRESHOLD:-60}
     LP_RUNTIME_THRESHOLD=${LP_RUNTIME_THRESHOLD:-2}
-    LP_RUNTIME_BELL=${LP_RUNTIME_BELL:-0}
+    LP_RUNTIME_BELL_THRESHOLD=${LP_RUNTIME_BELL_THRESHOLD:-10}
     LP_PATH_LENGTH=${LP_PATH_LENGTH:-35}
     LP_PATH_KEEP=${LP_PATH_KEEP:-2}
     LP_PATH_DEFAULT="${LP_PATH_DEFAULT:-$_LP_PWD_SYMBOL}"
@@ -328,6 +328,7 @@ _lp_source_config()
     LP_ENABLE_BZR=${LP_ENABLE_BZR:-1}
     LP_ENABLE_TIME=${LP_ENABLE_TIME:-0}
     LP_ENABLE_RUNTIME=${LP_ENABLE_RUNTIME:-1}
+    LP_ENABLE_RUNTIME_BELL=${LP_ENABLE_RUNTIME_BELL:-0}
     LP_ENABLE_VIRTUALENV=${LP_ENABLE_VIRTUALENV:-1}
     LP_ENABLE_SCLS=${LP_ENABLE_SCLS:-1}
     LP_ENABLE_VCS_ROOT=${LP_ENABLE_VCS_ROOT:-0}
@@ -1419,18 +1420,17 @@ _lp_runtime()
         (( _LP_RUNTIME_SECONDS >= 3600 )) && echo -n $((_LP_RUNTIME_SECONDS % 86400 / 3600))h
         (( _LP_RUNTIME_SECONDS >= 60 )) && echo -n $((_LP_RUNTIME_SECONDS % 3600 / 60))m
         echo -n $((_LP_RUNTIME_SECONDS % 60))"s${NO_COL}"
-        # if enabled, ring the bell
-        if (( LP_RUNTIME_BELL ))
-        then
-            #bash reprints $PS1 on every SIGWINCH, so we tput to stderr here so the bell is not
-            #captured in PS1.  This way the bell only rings once, not on every terminal resize.
-            tput bel >&2
-        fi
+    fi
+    if (( LP_ENABLE_RUNTIME_BELL && _LP_RUNTIME_SECONDS >= LP_RUNTIME_BELL_THRESHOLD ))
+    then
+        #bash reprints $PS1 on every SIGWINCH, so we tput to stderr here so the bell is not
+        #captured in PS1.  This way the bell only rings once, not on every terminal resize.
+        tput bel >&2
     fi
     :
 }
 
-if (( LP_ENABLE_RUNTIME )); then
+if (( LP_ENABLE_RUNTIME || LP_ENABLE_RUNTIME_BELL)); then
     if $_LP_SHELL_zsh; then
         _lp_runtime_before() {
           _LP_RUNTIME_LAST_SECONDS=$SECONDS

--- a/liquidprompt
+++ b/liquidprompt
@@ -302,6 +302,7 @@ _lp_source_config()
     LP_LOAD_THRESHOLD=${LP_LOAD_THRESHOLD:-60}
     LP_TEMP_THRESHOLD=${LP_TEMP_THRESHOLD:-60}
     LP_RUNTIME_THRESHOLD=${LP_RUNTIME_THRESHOLD:-2}
+    LP_RUNTIME_BELL=${LP_RUNTIME_BELL:-0}
     LP_PATH_LENGTH=${LP_PATH_LENGTH:-35}
     LP_PATH_KEEP=${LP_PATH_KEEP:-2}
     LP_PATH_DEFAULT="${LP_PATH_DEFAULT:-$_LP_PWD_SYMBOL}"
@@ -1418,6 +1419,11 @@ _lp_runtime()
         (( _LP_RUNTIME_SECONDS >= 3600 )) && echo -n $((_LP_RUNTIME_SECONDS % 86400 / 3600))h
         (( _LP_RUNTIME_SECONDS >= 60 )) && echo -n $((_LP_RUNTIME_SECONDS % 3600 / 60))m
         echo -n $((_LP_RUNTIME_SECONDS % 60))"s${NO_COL}"
+        # if enabled, ring the bell
+        if (( LP_RUNTIME_BELL ))
+        then
+            tput bel
+        fi
     fi
     :
 }

--- a/liquidpromptrc-dist
+++ b/liquidpromptrc-dist
@@ -129,7 +129,11 @@ LP_RUNTIME_THRESHOLD=2
 # Ring the terminal bell if the runtime of the previous command exceeded
 # LP_ENABLE_RUNTIME_THRESHOLD
 # Recommended value is 0
-LP_RUNTIME_BELL=0
+LP_ENABLE_RUNTIME_BELL=0
+
+# Minimal runtime (in seconds) before the terminal bell will be rung.
+# Recommended value is 10
+LP_RUNTIME_BELL_THRESHOLD=10
 
 # Display the virtualenv that is currently activated, if any
 # Recommended value is 1

--- a/liquidpromptrc-dist
+++ b/liquidpromptrc-dist
@@ -127,7 +127,7 @@ LP_ENABLE_RUNTIME=0
 LP_RUNTIME_THRESHOLD=2
 
 # Ring the terminal bell if the runtime of the previous command exceeded
-# LP_ENABLE_RUNTIME_THRESHOLD
+# LP_RUNTIME_BELL_THRESHOLD
 # Recommended value is 0
 LP_ENABLE_RUNTIME_BELL=0
 

--- a/liquidpromptrc-dist
+++ b/liquidpromptrc-dist
@@ -126,6 +126,11 @@ LP_ENABLE_RUNTIME=0
 # Recommended value is 2
 LP_RUNTIME_THRESHOLD=2
 
+# Ring the terminal bell if the runtime of the previous command exceeded
+# LP_ENABLE_RUNTIME_THRESHOLD
+# Recommended value is 0
+LP_RUNTIME_BELL=0
+
 # Display the virtualenv that is currently activated, if any
 # Recommended value is 1
 LP_ENABLE_VIRTUALENV=1


### PR DESCRIPTION
Disabled by default, if enabled the prompt will ring the terminal bell
after any command takes longer than LP_RUNTIME_THRESHOLD to execute.

This is handy when you have a long running process on a different
virtual desktop and want to be notified when it completes.