### PR TITLE
add Kubernetes context

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -177,6 +177,28 @@ General
 Features
 --------
 
+.. attribute:: LP_DELIMITER_KUBECONTEXT
+   :type: string
+   :value: ""
+
+   Delimiter to shorten the Kubernetes context.
+
+   Usage example:
+
+   * if your context names are dev-cluster and test-cluster,
+     then set this to "-" in order to output "dev" and "test" in prompt.
+   * if your context names are dev.k8s.example.com and test.k8s.example.com,
+     then set this to "." in order to output "dev" and "test" in prompt.
+   * if using OpenShift then set this to "/" to show only the project name
+     without the cluster and user parts.
+
+   If set to the empty string no truncating will occur (this is the default).
+
+   See also: :attr:`LP_ENABLE_KUBECONTEXT`, :attr:`LP_COLOR_KUBECONTEXT`,
+   and :attr:`LP_MARK_KUBECONTEXT`.
+
+   .. versionadded:: 2.1
+
 .. attribute:: LP_DISABLED_VCS_PATH
    :type: string
    :value: ""
@@ -330,6 +352,19 @@ Features
    Display the number of running and sleeping shell jobs.
 
    See also: :attr:`LP_COLOR_JOB_R` and :attr:`LP_COLOR_JOB_Z`.
+
+.. attribute:: LP_ENABLE_KUBECONTEXT
+   :type: bool
+   :value: 0
+
+   Display the current `Kubernetes <https://kubernetes.io/>`_ `context`_.
+
+   .. _`context`: https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/
+
+   See also: :attr:`LP_DELIMITER_KUBECONTEXT`, :attr:`LP_COLOR_KUBECONTEXT`,
+   and :attr:`LP_MARK_KUBECONTEXT`.
+
+   .. versionadded:: 2.1
 
 .. attribute:: LP_ENABLE_LOAD
    :type: bool
@@ -702,6 +737,26 @@ Marks
 
    See also: :attr:`LP_ENABLE_HG`.
 
+.. attribute:: LP_MARK_KUBECONTEXT
+   :type: string
+   :value: "⎈"
+
+   Mark used to prefix the current Kubernetes context.
+
+   Used to visually distinguish the Kubernetes context from other
+   context fields like the Python virtual environment (see
+   :attr:`LP_ENABLE_VIRTUALENV`) and the Red Hat Software Collection
+   (see :attr:`LP_ENABLE_SCLS`).
+
+   The display of Unicode characters varies among Terminal and Font settings,
+   so you might try alternative marks. Single symbol alternatives to the
+   default "⎈" (U+2388, Helm Symbol) are "☸" (U+2638, Wheel of Dharma)
+   or "κ" (U+03BA, Greek Small Letter Kappa).
+
+   See also: :attr:`LP_ENABLE_KUBECONTEXT`.
+
+   .. versionadded:: 2.1
+
 .. attribute:: LP_MARK_LOAD
    :type: string
    :value: "⌂"
@@ -957,6 +1012,16 @@ Valid preset color variables are:
    Color used for sleeping shell jobs.
 
    See also: :attr:`LP_ENABLE_JOBS`.
+
+.. attribute:: LP_COLOR_KUBECONTEXT
+   :type: string
+   :value: $CYAN
+
+   Color used for the current Kubernetes context.
+
+   See also: :attr:`LP_ENABLE_KUBECONTEXT`.
+
+   .. versionadded:: 2.1
 
 .. attribute:: LP_COLOR_MARK
    :type: string

--- a/docs/functions/data.rst
+++ b/docs/functions/data.rst
@@ -47,6 +47,17 @@ Battery
 Development Environment
 -----------------------
 
+.. function:: _lp_kubernetes_context() -> var:lp_kubernetes_context
+
+   Returns ``true`` if a Kubernetes context is found.
+   Returns the Kubernetes context name or the first name component.
+
+   Splitting long context names into components is defined by :attr:`LP_DELIMITER_KUBECONTEXT`.
+
+   Can be disabled by :attr:`LP_ENABLE_KUBECONTEXT`.
+
+   .. versionadded:: 2.1
+
 .. function:: _lp_python_env() -> var:lp_python_env
 
    Retuns ``true`` if a Python or Conda environment is detected. Returns the

--- a/docs/functions/theme.rst
+++ b/docs/functions/theme.rst
@@ -158,6 +158,13 @@ specific text and formatting may change.
       Return code matches data function.
       Return method changed from stdout.
 
+.. function:: _lp_kubernetes_context_color() -> var:lp_kubernetes_context_color
+
+   Returns data from :func:`_lp_kubernetes_context`, colored with
+   :attr:`LP_COLOR_KUBECONTEXT` and using mark :attr:`LP_MARK_KUBECONTEXT`.
+
+   .. versionadded:: 2.1
+
 .. function:: _lp_load_color() -> var:lp_load_color
 
    Returns :func:`_lp_load` with color from :attr:`LP_COLORMAP` and mark from

--- a/docs/theme/default.rst
+++ b/docs/theme/default.rst
@@ -180,6 +180,13 @@ default order if the user does not configure a different template.
    The current Python (or Conda) virtual environment. See
    :attr:`LP_ENABLE_VIRTUALENV`.
 
+.. attribute:: LP_KUBECONTEXT
+
+   The current Kubernetes context. See
+   :attr:`LP_ENABLE_KUBECONTEXT`.
+
+   .. versionadded:: 2.1
+
 .. attribute:: LP_PROXY
 
    A ↥ (:attr:`LP_MARK_PROXY`) if an HTTP proxy is in use. See

--- a/liquid.theme
+++ b/liquid.theme
@@ -24,6 +24,7 @@ if [[ "$(locale -k LC_CTYPE | sed -n 's/^charmap="\(.*\)"/\1/p')" == *"UTF-8"* ]
     LP_MARK_STASH="+"          # if git has stashs
     LP_MARK_SHORTEN_PATH=" … " # prompt mark in shortened paths
     LP_MARK_PERM=":"           # separator between host and path
+    LP_MARK_KUBECONTEXT="⎈"    # Kubernetes context
 else
     # If charset is anything else, fallback to ASCII chars
     LP_MARK_BATTERY="b"
@@ -40,6 +41,7 @@ else
     LP_MARK_STASH="+"
     LP_MARK_SHORTEN_PATH=" ... "
     LP_MARK_PERM=":"
+    LP_MARK_KUBECONTEXT="k8s:"
 fi
 
 LP_MARK_BRACKET_OPEN="["  # open bracket
@@ -115,6 +117,9 @@ LP_COLOR_IN_MULTIPLEXER="$BOLD_BLUE"
 
 # Virtual environment
 LP_COLOR_VIRTUALENV="$CYAN"
+
+# Kubernetes
+LP_COLOR_KUBECONTEXT="$CYAN"
 
 # Runtime
 LP_COLOR_RUNTIME="$YELLOW"

--- a/liquidprompt
+++ b/liquidprompt
@@ -194,6 +194,8 @@ __lp_source_config() {
     LP_PS1=${LP_PS1:-""}
     LP_PS1_PREFIX=${LP_PS1_PREFIX:-""}
     LP_PS1_POSTFIX=${LP_PS1_POSTFIX:-""}
+    LP_MARK_KUBECONTEXT=${LP_MARK_KUBECONTEXT:-"⎈"}
+    LP_DELIMITER_KUBECONTEXT=${LP_DELIMITER_KUBECONTEXT:-""}
 
     LP_ENABLE_PERM=${LP_ENABLE_PERM:-1}
     LP_ENABLE_SHORTEN_PATH=${LP_ENABLE_SHORTEN_PATH:-1}
@@ -224,6 +226,7 @@ __lp_source_config() {
     LP_ENABLE_COLOR=${LP_ENABLE_COLOR:-1}
     LP_ENABLE_ERROR=${LP_ENABLE_ERROR:-1}
     LP_ENABLE_DIRSTACK=${LP_ENABLE_DIRSTACK:-0}
+    LP_ENABLE_KUBECONTEXT=${LP_ENABLE_KUBECONTEXT:-0}
 
     LP_MARK_DEFAULT="${LP_MARK_DEFAULT:-$_LP_MARK_SYMBOL}"
     LP_MARK_BATTERY="${LP_MARK_BATTERY:-"⌁"}"
@@ -288,6 +291,7 @@ __lp_source_config() {
     LP_COLOR_RUNTIME=${LP_COLOR_RUNTIME:-$YELLOW}
     LP_COLOR_VIRTUALENV=${LP_COLOR_VIRTUALENV:-$CYAN}
     LP_COLOR_DIRSTACK=${LP_COLOR_DIRSTACK:-$BOLD_YELLOW}
+    LP_COLOR_KUBECONTEXT=${LP_COLOR_KUBECONTEXT:-$CYAN}
 
     if [[ -z "${LP_COLORMAP-}" ]]; then
         LP_COLORMAP=(
@@ -486,6 +490,8 @@ lp_activate() {
     else
         _lp_require_tool BATT acpi
     fi
+
+    _lp_require_tool KUBECONTEXT kubectl
 
     unset -f _lp_require_tool
 
@@ -1141,6 +1147,28 @@ _lp_software_collections_color() {
     _lp_software_collections || return "$?"
 
     lp_software_collections_color="[${LP_COLOR_VIRTUALENV}${lp_software_collections}${NO_COL}]"
+}
+
+
+_lp_kubernetes_context() {
+    (( LP_ENABLE_KUBECONTEXT )) || return 2
+
+    local kubernetes_context
+    kubernetes_context=$(kubectl config current-context 2>/dev/null) || return 1
+
+    if [[ -n "$LP_DELIMITER_KUBECONTEXT" ]]; then
+        kubernetes_context="${kubernetes_context%%${LP_DELIMITER_KUBECONTEXT}*}"
+    fi
+
+    local ret
+    __lp_escape "$kubernetes_context"
+    lp_kubernetes_context=$ret
+}
+
+_lp_kubernetes_context_color() {
+    _lp_kubernetes_context || return "$?"
+
+    lp_kubernetes_context_color="[${LP_MARK_KUBECONTEXT}${LP_COLOR_KUBECONTEXT}${lp_kubernetes_context}${NO_COL}]"
 }
 
 # Same as bash '\l', but can be inlined as a constant as the value will not
@@ -2695,6 +2723,12 @@ _lp_default_theme_prompt_data() {
         LP_VENV=
     fi
 
+    if _lp_kubernetes_context_color; then
+        LP_KUBECONTEXT=" $lp_kubernetes_context_color"
+    else
+        LP_KUBECONTEXT=
+    fi
+
     if _lp_software_collections_color; then
         LP_SCLS=" $lp_software_collections_color"
     else
@@ -2734,7 +2768,7 @@ _lp_default_theme_prompt_template() {
         # add user, host and permissions colon
         PS1+="${LP_BRACKET_OPEN}${LP_USER}${LP_HOST}${LP_PERM}"
 
-        PS1+="${LP_PWD}${LP_DIRSTACK}${LP_BRACKET_CLOSE}${LP_SCLS}${LP_VENV}${LP_PROXY}"
+        PS1+="${LP_PWD}${LP_DIRSTACK}${LP_BRACKET_CLOSE}${LP_SCLS}${LP_VENV}${LP_KUBECONTEXT}${LP_PROXY}"
 
         # Add VCS infos
         # If root, the info has not been collected unless LP_ENABLE_VCS_ROOT

--- a/liquidpromptrc-dist
+++ b/liquidpromptrc-dist
@@ -154,6 +154,14 @@ LP_ENABLE_VIRTUALENV=1
 # Recommended value is 1
 LP_ENABLE_SCLS=1
 
+# Show current Kubernetes kubectl context
+LP_ENABLE_KUBECONTEXT=0
+
+# Delimiter to shorten kubectl context.
+# E.g. when your context names are dev-cluster and test-cluster, set to "-"
+# in order to output "dev" and "test" in prompt.
+LP_DELIMITER_KUBECONTEXT=
+
 # Show highest system temperature
 LP_ENABLE_TEMP=1
 


### PR DESCRIPTION
This commit adds the current Kubernetes context to the prompt
(matches feature request #559).

I am not that good with shell programming and I have the feeling the unconditional call to `_lp_kube_context` could be handled more elegantly. So any suggestions for improvements are welcome.