### PR TITLE
Fix battery charging symbol

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -1289,6 +1289,9 @@ case "$LP_OS" in
         if [[ "$acpi" == *"Discharging"* ]]; then
             # under => 0, above => 1
             return $(( bat > LP_BATTERY_THRESHOLD ))
+        # not charging
+        elif [[ "$acpi" == *"Not charging"* ]]; then
+            return 4
         # charging
         else
             # under => 2, above => 3

--- a/liquidprompt
+++ b/liquidprompt
@@ -1292,7 +1292,7 @@ case "$LP_OS" in
         # charging
         else
             # under => 2, above => 3
-            return $(( 1 + ( bat > LP_BATTERY_THRESHOLD ) ))
+            return $(( 2 + ( bat > LP_BATTERY_THRESHOLD ) ))
         fi
     }
     ;;
@@ -1314,7 +1314,7 @@ case "$LP_OS" in
             *)  # "charging", "AC attached"
                 echo -nE "$percent"
                 # under => 2, above => 3
-                return $(( 1 + ( percent > LP_BATTERY_THRESHOLD ) ))
+                return $(( 2 + ( percent > LP_BATTERY_THRESHOLD ) ))
             ;;
         esac
     }


### PR DESCRIPTION
Return code of `_lp_battery` when charging was [1, 2], now it is the
desired [2, 3].

 *1 => discharging above threshold
 *2 => charging under threshold
 *3 => charging above threshold