### PR TITLE
Added zinit installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,15 @@ To install via antigen, simply add the following line in your `.zshrc` after act
 
     antigen bundle nojhan/liquidprompt
 
+### Installation via zinit
+
+To install via zinit, simply add the following lines to your `.zshrc` after activating zinit:
+
+    zinit ice load'[[ $- = *i* ]]' \
+	            wait'!' \
+	            lucid nocd \
+	            atload'!_lp_set_prompt'
+    zinit load nojhan/liquidprompt
 
 ## Dependencies
 


### PR DESCRIPTION
I recently made the switch to [zinit](https://github.com/zdharma/zinit), and wanted to keep liquidprompt. One of the cool things `zinit` does (and as far as I can tell it works perfectly with liquidprompt!) is to be able to load plugins asynchronously.

This PR contains the configuration I use to setup liquidprompt asynchronously using zinit.