### PR TITLE
suppress error messages on each prompt

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -1598,7 +1598,7 @@ if (( LP_ENABLE_TEMP )); then
         # Return the hottest system temperature we get through the sensors command
         # Only the integer part is retained
         local -i i
-        for i in $(sensors -u |
+        for i in $(sensors -u 2>/dev/null |
                 sed -n 's/^  temp[0-9][0-9]*_input: \([0-9]*\)\..*$/\1/p'); do
             (( $i > ${temperature:-0} )) && temperature=i
         done


### PR DESCRIPTION
Seen after an online update to kernel 5.3.0-42 on Linux Mint Tricia.
With this kernel, /usr/bin/sensors -u babbles on stderr, as - yes - my
/sys/class/hwmon/hwmon4/temp2_input is not readable. All other temp*_input are readable.

As part of liquidprompt the output is not helpful. Users have no context. (the command that fails is not mentioned, the /sys/ node that fails is not mentioned). Users get spammed with the error. (seen on every prompt)