### PR TITLE
load: do not attempt to infer CPU utilisation from load average

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ variety of Unix systems: `tput`, `grep`, `awk`, `sed`, `ps`, `who`, and `expr`.
 You can configure some variables in the `~/.config/liquidpromptrc` file:
 
 * `LP_BATTERY_THRESHOLD`, the maximal value under which the battery level is displayed
-* `LP_LOAD_THRESHOLD`, the minimal value after which the load average is displayed
+* `LP_LOAD_THRESHOLD`, the minimal value (centiload per cpu) after which the load average is displayed
 * `LP_TEMP_THRESHOLD`, the minimal value after which the average temperature is displayed
 * `LP_RUNTIME_THRESHOLD`, the minimal value after which the runtime is displayed
 * `LP_RUNTIME_BELL_THRESHOLD`, the minimal value after which the bell is rung. See LP_ENABLE_RUNTIME_BELL.

--- a/liquidprompt
+++ b/liquidprompt
@@ -1488,7 +1488,7 @@ _lp_load_color()
     local -i load=${lp_cpu_load:-0}/$_lp_CPUNUM
 
     if (( load > LP_LOAD_THRESHOLD )); then
-        local ret="$(_lp_color_map $load)${LP_MARK_LOAD}"
+        local ret="$(_lp_color_map $load 200)${LP_MARK_LOAD}"
 
         if (( LP_PERCENTS_ALWAYS )); then
             ret+="${true_load}"

--- a/liquidprompt
+++ b/liquidprompt
@@ -1386,6 +1386,8 @@ _lp_color_map() {
     scale=${2:-100}
     # Transform the value to a 0..${#COLOR_MAP} scale
     idx=_LP_FIRST_INDEX+100*$1/scale/${#LP_COLORMAP[*]}
+    # When off the scale, use the "highest" available color
+    (( idx < ${#LP_COLORMAP[*]} )) || idx=${#LP_COLORMAP[*]}-1
     echo -nE "${LP_COLORMAP[idx]}"
 }
 

--- a/liquidprompt
+++ b/liquidprompt
@@ -1480,6 +1480,7 @@ _lp_load_color()
     local lp_cpu_load
     # Get value (OS-specific) into lp_cpu_load
     _lp_cpu_load
+    local true_load=$lp_cpu_load
 
     lp_cpu_load=${lp_cpu_load/./}   # Remove '.'
     lp_cpu_load=${lp_cpu_load#0}    # Remove leading '0'
@@ -1490,7 +1491,7 @@ _lp_load_color()
         local ret="$(_lp_color_map $load)${LP_MARK_LOAD}"
 
         if (( LP_PERCENTS_ALWAYS )); then
-            ret+="${load}"
+            ret+="${true_load}"
         fi
         echo -nE "${ret}${NO_COL}"
     fi

--- a/liquidprompt
+++ b/liquidprompt
@@ -1490,7 +1490,7 @@ _lp_load_color()
         local ret="$(_lp_color_map $load)${LP_MARK_LOAD}"
 
         if (( LP_PERCENTS_ALWAYS )); then
-            ret+="${load}${_LP_PERCENT}"
+            ret+="${load}"
         fi
         echo -nE "${ret}${NO_COL}"
     fi

--- a/liquidpromptrc-dist
+++ b/liquidpromptrc-dist
@@ -16,7 +16,12 @@
 # Recommended value is 75
 LP_BATTERY_THRESHOLD=75
 
-# Display the load average when the load is above this threshold.
+# Display the load average over the past minute when above this threshold.
+# The value is expressed in centiload per CPU. For example, when using the
+# default value of 60, the load average will be displayed starting at:
+# * 0.61 on a single-core machine, or
+# * 1.22 on a dual-core machine, or
+# * 2.44 on a quad-core machine, and so on.
 # Recommended value is 60
 LP_LOAD_THRESHOLD=60
 


### PR DESCRIPTION
Liquidprompt's load feature currently assumes, incorrectly, that the
load average is a percentage (it isn't) that can be converted directly
to CPU utilisation (it can't).

Because the load average is a gauge reading with an essentially
unlimited ceiling, ensure the colouring function is passed an
appropriate ceiling instead of the default value of 100. This ceiling is
now set (rather arbitrarily) at 20*$LP_LOAD_THRESHOLD, meaning the
"highest" colour starts being used at 18*$LP_LOAD_THRESHOLD.

To handle the case where the actual load exceeds the
20*$LP_LOAD_THRESHOLD ceiling, the _lp_color_map() function is changed
to apply the "highest" colour (instead of no colour) whenever the
supplied value exceeds the ceiling of the scale. This change is an
alternative implementation of what has already been proposed in #455.

Finally, it improves the documentation of the LP_LOAD_THRESHOLD value to
make it clear that it represents a centiload value that will be
multiplied with the number of CPUs in the system to calculate the actual
load average threshold that will be compared with the system's
representation of the load average.

Closes #499, closes #530.

Signed-off-by: Tore Anderson <tore@fud.no>