### PR TITLE
Add option to insert newline when prompt is long

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -96,6 +96,7 @@ Thanks again to everyone for all of the help and support!
 * Tristan Miller (@logological)
 * Markus Gebert (@mgeb)
 * Tore Anderson (@toreanderson)
+* William S. (@PandaWill)
 
 ### Code cleanup
 * Aurélien Requiem (@aureq)

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ You can configure some variables in the `~/.config/liquidpromptrc` file:
   showing it only when connected via a remote shell (0) or never showing it (-1).
 * `LP_USER_ALWAYS`, a choice between always displaying the user or showing
   it only when he is different from the one that logged in
+* `LP_MINIMUM_SPACE_AFTER_PROMPT`, the minimum number of free columns required after a prompt, a new line is added if the number of free columns is below this.
 
 You can also force some features to be disabled, to save some time in the
 prompt-building process:

--- a/liquidprompt
+++ b/liquidprompt
@@ -299,6 +299,7 @@ _lp_source_config()
     LP_PS1=${LP_PS1:-""}
     LP_PS1_PREFIX=${LP_PS1_PREFIX:-""}
     LP_PS1_POSTFIX=${LP_PS1_POSTFIX:-""}
+    LP_MINIMUM_SPACE_AFTER_PROMPT=${LP_MINIMUM_SPACE_AFTER_PROMPT:-0}
 
     LP_ENABLE_PERM=${LP_ENABLE_PERM:-1}
     LP_ENABLE_SHORTEN_PATH=${LP_ENABLE_SHORTEN_PATH:-1}
@@ -1594,6 +1595,23 @@ _lp_as_text()
     echo -nE "$1" | sed -$_LP_SED_EXTENDED "s,$_LP_CLEAN_ESC,,g"
 }
 
+# Get length of a given string, after evaluating escape codes (\u for user, etc)
+_lp_length()
+{
+    typeset len evaluated_ps1
+    typeset printable_ps1=$(_lp_as_text "$1")
+
+    if $_LP_SHELL_bash; then
+        evaluated_ps1=$(printf '%s' "${printable_ps1@P}")
+    else # zsh
+        evaluated_ps1=$(print -P $printable_ps1)
+    fi
+
+    len=${#evaluated_ps1}
+
+    echo $len
+}
+
 _lp_title()
 {
     (( LP_ENABLE_TITLE )) || return
@@ -1849,8 +1867,18 @@ _lp_set_prompt()
         # is set.
         PS1+="${LP_VCS}"
 
-        # add return code and prompt mark
-        PS1+="${LP_RUNTIME}${LP_ERR}${LP_MARK_PREFIX}${LP_COLOR_MARK}${LP_MARK}${LP_PS1_POSTFIX}"
+        # add return code
+        PS1+="${LP_RUNTIME}${LP_ERR}"
+
+        # determine if we need to add new line before prompt mark
+        if (( LP_MINIMUM_SPACE_AFTER_PROMPT )); then
+            if [[ $(_remaining_space) -lt "$LP_MINIMUM_SPACE_AFTER_PROMPT" ]]; then
+                PS1+=$'\n'
+            fi
+        fi
+
+        # add prompt mark
+        PS1+="${LP_MARK_PREFIX}${LP_COLOR_MARK}${LP_MARK}${LP_PS1_POSTFIX}"
 
         # "invisible" parts
         # Get the current prompt on the fly and make it a title
@@ -1866,6 +1894,17 @@ _lp_set_prompt()
     else
         PS1=$LP_PS1
     fi
+}
+
+# Calculates the remaining space on a terminal line after prompt has been printed
+_remaining_space()
+{
+    typeset len=$(_lp_length "$PS1")
+
+    # Modulo terminal width, so we handle the case where prompt is already on a new line
+    remaining_space=$(( $COLUMNS - ( $len % $COLUMNS ) ))
+
+    echo $remaining_space
 }
 
 prompt_tag()

--- a/liquidpromptrc-dist
+++ b/liquidpromptrc-dist
@@ -176,4 +176,8 @@ LP_ENABLE_SSH_COLORS=0
 # will be disabled
 LP_DISABLED_VCS_PATH=""
 
+# Require minimum number of columns in the terminal after the prompt.
+# Default is 0 (off), sensible values are around 20 or 30.
+LP_MINIMUM_SPACE_AFTER_PROMPT=0
+
 # vim: set et sts=4 sw=4 tw=120 ft=sh:


### PR DESCRIPTION
Add new setting `LP_MINIMUM_CMD_LENGTH`, which controls when a newline is added. Setting defaults to 0 (disabled).

See feature request #599.

I had to use perl for removing the non-printable characters from the prompt. It doesn't feel like the nicest solution, but I couldn't remove them with bash pattern matching or sed. This was due to the requirement to match the 2 characters at the end of each block: `\]` .

Let me know if there's anything you'd like changed, I'm keen to do all I can to get this merged. I only discovered this project recently and it's almost perfect - this is the missing piece of the puzzle for me!


