### PR TITLE
Implement temperature monitoring with direct sysfs access

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -1504,6 +1504,17 @@ if (( LP_ENABLE_TEMP )); then
 
     # Backends for TEMP. Each backend must return the result in $temperature.
 
+    # Implementation directly accessing sysfs
+    _lp_temp_hwmon() {
+      [ "$LP_TEMP_HWMON" ] || return 0
+      [ -e "/sys/class/hwmon/$LP_TEMP_HWMON" ] || return 0
+
+      local -i temp
+      read temp < /sys/class/hwmon/$LP_TEMP_HWMON
+      [ "$temp" ] || return 0
+      temperature=$((temp / 1000))
+    }
+
     # Implementation using lm-sensors
     _lp_temp_sensors()
     {
@@ -1555,7 +1566,7 @@ if (( LP_ENABLE_TEMP )); then
 
     # Try each _lp_temp method
     # If no function worked, disable the feature
-    _lp_temp_detect acpi sensors || LP_ENABLE_TEMP=0
+    _lp_temp_detect hwmon acpi sensors || LP_ENABLE_TEMP=0
     unset -f _lp_temp_detect
 fi
 

--- a/liquidpromptrc-dist
+++ b/liquidpromptrc-dist
@@ -30,6 +30,10 @@ LP_LOAD_THRESHOLD=60
 # Recommended value is 60
 LP_TEMP_THRESHOLD=60
 
+# The path to a file relative to /sys/class/hwmon/, containing a
+# temperature reading expressed in 1/1000 degrees.
+LP_TEMP_HWMON=""
+
 # Use the shorten path feature if the path is too long to fit in the prompt
 # line.
 # Recommended value is 1


### PR DESCRIPTION
I am proposing an implementation of temperature monitoring which does not require executing other binaries (as is being discussed in https://github.com/nojhan/liquidprompt/issues/607).
For the time being users need to set `LP_TEMP_HWMON` to a value like `hwmon4/temp1_input` after checking which sensor makes more sense for them, but with some more work it would not be hard to use e.g. the first CPU core as the default sensor.