### PR TITLE
Directory stack support

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -582,7 +582,7 @@ Marks
    Mark used to indicate the size of the directory stack. Here are some
    alternative marks you might like: ⚟ = ≡ ≣
 
-   See also :attr:`LP_ENABLE_DIRSTACK` and :attr:`LP_COLOR_DIRSTACK`.
+   See also: :attr:`LP_ENABLE_DIRSTACK` and :attr:`LP_COLOR_DIRSTACK`.
 
    .. versionadded:: 2.0
 
@@ -805,7 +805,7 @@ Valid preset color variables are:
 
    Color used to indicate the size of the directory stack.
 
-   See also :attr:`LP_ENABLE_DIRSTACK` and :attr:`LP_MARK_DIRSTACK`.
+   See also: :attr:`LP_ENABLE_DIRSTACK` and :attr:`LP_MARK_DIRSTACK`.
 
    .. versionadded:: 2.0
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -190,6 +190,16 @@ Features
 
    .. versionadded:: 2.0
 
+.. attribute:: LP_ENABLE_DIRSTACK
+   :type: bool
+   :value: 0
+
+   Display the size of the directory stack if it is greater than ``1``.
+
+   See also: :attr:`LP_MARK_DIRSTACK` and :attr:`LP_COLOR_DIRSTACK`.
+
+   .. versionadded:: 2.0
+
 .. attribute:: LP_ENABLE_ERROR
    :type: bool
    :value: 1
@@ -565,6 +575,17 @@ Marks
    Mark used to indicate that the prompt is ready for user input, unless some
    other context overrides it, like a VCS repository.
 
+.. attribute:: LP_MARK_DIRSTACK
+   :type: string
+   :value: "⚞"
+
+   Mark used to indicate the size of the directory stack. Here are some
+   alternative marks you might like: ⚟ = ≡ ≣
+
+   See also :attr:`LP_ENABLE_DIRSTACK` and :attr:`LP_COLOR_DIRSTACK`.
+
+   .. versionadded:: 2.0
+
 .. attribute:: LP_MARK_DISABLED
    :type: string
    :value: "⌀"
@@ -777,6 +798,16 @@ Valid preset color variables are:
 
    Color used to indicate that the current repository has lines that have been
    changed since the last commit.
+
+.. attribute:: LP_COLOR_DIRSTACK
+   :type: string
+   :value: $BOLD_YELLOW
+
+   Color used to indicate the size of the directory stack.
+
+   See also :attr:`LP_ENABLE_DIRSTACK` and :attr:`LP_MARK_DIRSTACK`.
+
+   .. versionadded:: 2.0
 
 .. attribute:: LP_COLOR_DISCHARGING_ABOVE
    :type: string

--- a/docs/functions/data.rst
+++ b/docs/functions/data.rst
@@ -99,6 +99,16 @@ Environment
    .. versionchanged:: 2.0
       Return method changed from stdout.
 
+.. function:: _lp_dirstack() -> var:lp_dirstack
+
+    Returns true if directory stack support is enabled and the directory stack
+    contains more than one directory. In that case, the return variable is set
+    to the number of directories on the stack.
+
+    Can be enabled by :attr:`LP_ENABLE_DIRSTACK`.
+
+    .. versionadded:: 2.0
+
 .. function:: _lp_error() -> var:lp_error
 
    Returns ``true`` if the last user shell command returned a non-zero exit

--- a/docs/functions/data.rst
+++ b/docs/functions/data.rst
@@ -101,9 +101,9 @@ Environment
 
 .. function:: _lp_dirstack() -> var:lp_dirstack
 
-    Returns true if directory stack support is enabled and the directory stack
-    contains more than one directory. In that case, the return variable is set
-    to the number of directories on the stack.
+    Returns ``true`` if directory stack support is enabled and the directory
+    stack contains more than one directory. In that case, the return variable
+    is set to the number of directories on the stack.
 
     Can be enabled by :attr:`LP_ENABLE_DIRSTACK`.
 

--- a/docs/functions/theme.rst
+++ b/docs/functions/theme.rst
@@ -97,6 +97,13 @@ specific text and formatting may change.
       Return code matches data function.
       Return method changed from stdout.
 
+.. function:: _lp_dirstack_color() -> var:lp_dirstack_color
+
+    Returns :func:`_lp_dirstack`, prefixed with :attr:`LP_MARK_DIRSTACK`, all
+    colored with :attr:`LP_COLOR_DIRSTACK`.
+
+    .. versionadded:: 2.0
+
 .. function:: _lp_error_color() -> var:lp_error_color
 
    Returns :func:`_lp_error` with color from :attr:`LP_COLOR_ERR`.

--- a/docs/theme/default.rst
+++ b/docs/theme/default.rst
@@ -156,6 +156,12 @@ default order if the user does not configure a different template.
    The current working directory in bold, shortened if it takes too much space.
    See :attr:`LP_ENABLE_SHORTEN_PATH`.
 
+.. attribute:: LP_DIRSTACK
+
+   The size of the directory stack, prefixed with :attr:`LP_MARK_DIRSTACK`, all
+   colored with :attr:`LP_COLOR_DIRSTACK`. Can be enabled by
+   :attr:`LP_ENABLE_DIRSTACK`.
+
 .. attribute:: LP_BRACKET_CLOSE
 
    A closing bracket, designed to go around the core of the prompt (generally

--- a/docs/theme/included/powerline.rst
+++ b/docs/theme/included/powerline.rst
@@ -306,6 +306,12 @@ _______
 
    The marker string used to indicate the following string is a chroot.
 
+.. attribute:: POWERLINE_DIRSTACK_MARKER
+   :type: string
+   :value: "⚞"
+
+   The marker string used to indicate the size of the directory stack.
+
 .. attribute:: POWERLINE_PROXY_MARKER
    :type: string
    :value: "proxy: "

--- a/docs/theme/included/powerline.rst
+++ b/docs/theme/included/powerline.rst
@@ -306,12 +306,6 @@ _______
 
    The marker string used to indicate the following string is a chroot.
 
-.. attribute:: POWERLINE_DIRSTACK_MARKER
-   :type: string
-   :value: "⚞"
-
-   The marker string used to indicate the size of the directory stack.
-
 .. attribute:: POWERLINE_PROXY_MARKER
    :type: string
    :value: "proxy: "
@@ -339,6 +333,12 @@ ______
    :value: (219, 30, 0, 0, 7, 4)
 
    Color for the chroot section.
+
+.. attribute:: POWERLINE_DIRSTACK_COLOR
+   :type: array<int>
+   :value: :attr:`POWERLINE_NEUTRAL_COLOR`
+
+   Color for the directory stack section.
 
 .. attribute:: POWERLINE_LOAD_COLOR
    :type: array<int>

--- a/liquidprompt
+++ b/liquidprompt
@@ -219,6 +219,7 @@ __lp_source_config() {
     LP_ENABLE_SUDO=${LP_ENABLE_SUDO:-0}
     LP_ENABLE_COLOR=${LP_ENABLE_COLOR:-1}
     LP_ENABLE_ERROR=${LP_ENABLE_ERROR:-1}
+    LP_ENABLE_DIRSTACK=${LP_ENABLE_DIRSTACK:-0}
 
     LP_MARK_DEFAULT="${LP_MARK_DEFAULT:-$_LP_MARK_SYMBOL}"
     LP_MARK_BATTERY="${LP_MARK_BATTERY:-"⌁"}"
@@ -240,6 +241,7 @@ __lp_source_config() {
     LP_MARK_SHORTEN_PATH="${LP_MARK_SHORTEN_PATH:-" … "}"
     LP_MARK_PREFIX="${LP_MARK_PREFIX:-" "}"
     LP_MARK_PERM="${LP_MARK_PERM:-":"}"
+    LP_MARK_DIRSTACK="${LP_MARK_DIRSTACK:-"⚞"}"     # alternatives: ⚟ = ≡ ≣
 
     LP_COLOR_PATH=${LP_COLOR_PATH:-$BOLD}
     LP_COLOR_PATH_ROOT=${LP_COLOR_PATH_ROOT:-$BOLD_YELLOW}
@@ -275,6 +277,7 @@ __lp_source_config() {
     LP_COLOR_IN_MULTIPLEXER=${LP_COLOR_IN_MULTIPLEXER:-$BOLD_BLUE}
     LP_COLOR_RUNTIME=${LP_COLOR_RUNTIME:-$YELLOW}
     LP_COLOR_VIRTUALENV=${LP_COLOR_VIRTUALENV:-$CYAN}
+    LP_COLOR_DIRSTACK=${LP_COLOR_DIRSTACK:-$BOLD_YELLOW}
 
     if [[ -z "${LP_COLORMAP-}" ]]; then
         LP_COLORMAP=(
@@ -1135,6 +1138,27 @@ _lp_jobcount_color() {
     fi
 
     [[ -n "$lp_jobcount_color" ]]
+}
+
+###################
+# Directory stack #
+###################
+
+_lp_dirstack() {
+    (( LP_ENABLE_DIRSTACK )) || return 2
+
+    lp_dirstack=
+
+    local -i ds
+    (( ds = $(dirs -p | wc -l) ))
+
+    if (( ds > 1 )); then
+        lp_dirstack+="${LP_COLOR_DIRSTACK}${LP_MARK_DIRSTACK}${ds}${NO_COL}"
+    else
+        return 1
+    fi
+
+    return 0
 }
 
 ######################
@@ -2432,6 +2456,12 @@ _lp_default_theme_prompt() {
         LP_VCS=
     fi
 
+    if _lp_dirstack; then
+        LP_STCK=" $lp_dirstack"
+    else
+        LP_STCK=
+    fi
+
     _lp_smart_mark
     LP_MARK="${lp_smart_mark}${NO_COL} "
 
@@ -2445,7 +2475,7 @@ _lp_default_theme_prompt() {
         # add user, host and permissions colon
         PS1+="${LP_BRACKET_OPEN}${LP_USER}${LP_HOST}${LP_PERM}"
 
-        PS1+="${LP_PWD}${LP_BRACKET_CLOSE}${LP_SCLS}${LP_VENV}${LP_PROXY}"
+        PS1+="${LP_PWD}${LP_STCK}${LP_BRACKET_CLOSE}${LP_SCLS}${LP_VENV}${LP_PROXY}"
 
         # Add VCS infos
         # If root, the info has not been collected unless LP_ENABLE_VCS_ROOT

--- a/liquidprompt
+++ b/liquidprompt
@@ -1081,6 +1081,22 @@ _lp_hostname_color() {
     fi
 }
 
+_lp_dirstack() {
+    (( LP_ENABLE_DIRSTACK )) || return 2
+
+    local count dir_stack=$(dirs -p; printf x)
+    __lp_line_count "${dir_stack%x}"
+    lp_dirstack=$count
+
+    (( lp_dirstack > 1 ))
+}
+
+_lp_dirstack_color() {
+    _lp_dirstack || return "$?"
+
+    lp_dirstack_color="${LP_COLOR_DIRSTACK}${LP_MARK_DIRSTACK}${lp_dirstack}${NO_COL}"
+}
+
 ################
 # Related jobs #
 ################
@@ -1138,27 +1154,6 @@ _lp_jobcount_color() {
     fi
 
     [[ -n "$lp_jobcount_color" ]]
-}
-
-###################
-# Directory stack #
-###################
-
-_lp_dirstack() {
-    (( LP_ENABLE_DIRSTACK )) || return 2
-
-    lp_dirstack=
-
-    local -i ds
-    (( ds = $(dirs -p | wc -l) ))
-
-    if (( ds > 1 )); then
-        lp_dirstack+="${LP_COLOR_DIRSTACK}${LP_MARK_DIRSTACK}${ds}${NO_COL}"
-    else
-        return 1
-    fi
-
-    return 0
 }
 
 ######################
@@ -2419,6 +2414,12 @@ _lp_default_theme_prompt() {
         LP_COLOR_MARK="$lp_sudo_active_color"
     fi
 
+    if _lp_dirstack_color; then
+        LP_DIRSTACK=" $lp_dirstack_color"
+    else
+        LP_DIRSTACK=
+    fi
+
     # in main prompt: no space
     if _lp_http_proxy_color; then
         LP_PROXY="$lp_http_proxy_color"
@@ -2456,12 +2457,6 @@ _lp_default_theme_prompt() {
         LP_VCS=
     fi
 
-    if _lp_dirstack; then
-        LP_STCK=" $lp_dirstack"
-    else
-        LP_STCK=
-    fi
-
     _lp_smart_mark
     LP_MARK="${lp_smart_mark}${NO_COL} "
 
@@ -2475,7 +2470,7 @@ _lp_default_theme_prompt() {
         # add user, host and permissions colon
         PS1+="${LP_BRACKET_OPEN}${LP_USER}${LP_HOST}${LP_PERM}"
 
-        PS1+="${LP_PWD}${LP_STCK}${LP_BRACKET_CLOSE}${LP_SCLS}${LP_VENV}${LP_PROXY}"
+        PS1+="${LP_PWD}${LP_DIRSTACK}${LP_BRACKET_CLOSE}${LP_SCLS}${LP_VENV}${LP_PROXY}"
 
         # Add VCS infos
         # If root, the info has not been collected unless LP_ENABLE_VCS_ROOT

--- a/liquidprompt
+++ b/liquidprompt
@@ -241,7 +241,7 @@ __lp_source_config() {
     LP_MARK_SHORTEN_PATH="${LP_MARK_SHORTEN_PATH:-" … "}"
     LP_MARK_PREFIX="${LP_MARK_PREFIX:-" "}"
     LP_MARK_PERM="${LP_MARK_PERM:-":"}"
-    LP_MARK_DIRSTACK="${LP_MARK_DIRSTACK:-"⚞"}"     # alternatives: ⚟ = ≡ ≣
+    LP_MARK_DIRSTACK="${LP_MARK_DIRSTACK:-"⚞"}"
 
     LP_COLOR_PATH=${LP_COLOR_PATH:-$BOLD}
     LP_COLOR_PATH_ROOT=${LP_COLOR_PATH_ROOT:-$BOLD_YELLOW}

--- a/liquidpromptrc-dist
+++ b/liquidpromptrc-dist
@@ -102,6 +102,9 @@ LP_ENABLE_BATT=1
 # credentials, and the sysadmin might hate you.
 LP_ENABLE_SUDO=0
 
+# Enable the directory stack support.
+LP_ENABLE_DIRSTACK=0
+
 # Enable the VCS features with the root account.
 # Recommended value is 0
 LP_ENABLE_VCS_ROOT=0

--- a/themes/powerline/powerline.theme
+++ b/themes/powerline/powerline.theme
@@ -120,7 +120,6 @@ _lp_powerline_full_theme_activate() {
     POWERLINE_CHROOT_MARKER=${POWERLINE_CHROOT_MARKER:-"chroot: "}
     POWERLINE_PROXY_MARKER=${POWERLINE_PROXY_MARKER:-"proxy: "}
     POWERLINE_SOFTWARE_COLLECTION_MARKER=${POWERLINE_SOFTWARE_COLLECTION_MARKER:-"(sc) "}
-    POWERLINE_DIRSTACK_MARKER=${POWERLINE_DIRSTACK_MARKER:-"⚞"}
 
     # Load default colors if not already defined
     [[ -z ${POWERLINE_BATTERY_COLOR[@]+x}              ]] && POWERLINE_BATTERY_COLOR=(-1 238 0 0 -1 0)
@@ -132,6 +131,7 @@ _lp_powerline_full_theme_activate() {
     [[ -z ${POWERLINE_SOFTWARE_COLLECTIONS_COLOR[@]+x} ]] && POWERLINE_SOFTWARE_COLLECTIONS_COLOR=(231 62 0 0 7 5)
     [[ -z ${POWERLINE_TEMPERATURE_COLOR[@]+x}          ]] && POWERLINE_TEMPERATURE_COLOR=(-1 240 0 0 -1 0)
     [[ -z ${POWERLINE_TIME_COLOR[@]+x}                 ]] && POWERLINE_TIME_COLOR=(33 17 0 0 5 4)
+    [[ -z ${POWERLINE_DIRSTACK_COLOR[@]+x}             ]] && POWERLINE_DIRSTACK_COLOR=("${POWERLINE_NEUTRAL_COLOR[@]}")
 }
 
 _lp_powerline_full_theme_directory() {
@@ -183,6 +183,10 @@ _lp_powerline_full_theme_prompt() {
     __powerline_section "${_POWERLINE_HOST_ICON}${_POWERLINE_HOSTNAME}" "${POWERLINE_HOST_COLOR[@]}"
 
     __powerline_path_section
+
+    if _lp_dirstack; then
+        __powerline_section "${LP_MARK_DIRSTACK}${lp_dirstack}" "${POWERLINE_DIRSTACK_COLOR[@]}"
+    fi
 
     local lp_chroot
     if _lp_chroot; then
@@ -305,19 +309,10 @@ __powerline_path_split() {  # path_format, [separator_format], [last_dir_format]
 # __powerline_path_split(), which forgets the old colors for the arrow. This
 # function lets the arrow go first.
 __powerline_path_section() {
-    local powerline_path section_arrow dirstack_indicator
+    local powerline_path section_arrow
     __powerline_section_arrow "${POWERLINE_PATH_COLOR[@]}"
     __powerline_path_split
-    __powerline_dirstack_indicator
-    powerline_sections+="${section_arrow}${powerline_path}${dirstack_indicator}"
-}
-
-__powerline_dirstack_indicator() {
-    if _lp_dirstack; then
-        dirstack_indicator="${POWERLINE_DIRSTACK_MARKER}${lp_dirstack}${POWERLINE_SPACER}"
-    else
-        dirstack_indicator=
-    fi
+    powerline_sections+=${section_arrow}${powerline_path}
 }
 
 # Is this a dirty hack? Yes. Am I proud of it? Also yes.

--- a/themes/powerline/powerline.theme
+++ b/themes/powerline/powerline.theme
@@ -120,6 +120,7 @@ _lp_powerline_full_theme_activate() {
     POWERLINE_CHROOT_MARKER=${POWERLINE_CHROOT_MARKER:-"chroot: "}
     POWERLINE_PROXY_MARKER=${POWERLINE_PROXY_MARKER:-"proxy: "}
     POWERLINE_SOFTWARE_COLLECTION_MARKER=${POWERLINE_SOFTWARE_COLLECTION_MARKER:-"(sc) "}
+    POWERLINE_DIRSTACK_MARKER=${POWERLINE_DIRSTACK_MARKER:-"⚞"}
 
     # Load default colors if not already defined
     [[ -z ${POWERLINE_BATTERY_COLOR[@]+x}              ]] && POWERLINE_BATTERY_COLOR=(-1 238 0 0 -1 0)
@@ -304,10 +305,19 @@ __powerline_path_split() {  # path_format, [separator_format], [last_dir_format]
 # __powerline_path_split(), which forgets the old colors for the arrow. This
 # function lets the arrow go first.
 __powerline_path_section() {
-    local powerline_path section_arrow
+    local powerline_path section_arrow dirstack_indicator
     __powerline_section_arrow "${POWERLINE_PATH_COLOR[@]}"
     __powerline_path_split
-    powerline_sections+=${section_arrow}${powerline_path}
+    __powerline_dirstack_indicator
+    powerline_sections+="${section_arrow}${powerline_path}${dirstack_indicator}"
+}
+
+__powerline_dirstack_indicator() {
+    if _lp_dirstack; then
+        dirstack_indicator="${POWERLINE_DIRSTACK_MARKER}${lp_dirstack}${POWERLINE_SPACER}"
+    else
+        dirstack_indicator=
+    fi
 }
 
 # Is this a dirty hack? Yes. Am I proud of it? Also yes.


### PR DESCRIPTION
Hi,

I noticed that liquidprompt doesn't show information about the directory stack ([bash](https://www.gnu.org/software/bash/manual/html_node/The-Directory-Stack.html)/[zsh](http://zsh.sourceforge.net/Intro/intro_6.html)), so I made a little sketch of an implementation. I tested it on bash but it should work just as well with zsh.

![Screenshot_20201017_032016](https://user-images.githubusercontent.com/15108787/96325510-99ccbc80-1028-11eb-949a-c922d03f149f.png)

Let me know what you think! 