### PR TITLE
Display current mercurial bookmark, if any

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -990,8 +990,12 @@ _lp_hg_branch()
 
     local branch
     branch="$(hg branch 2>/dev/null)"
-
-    (( $? == 0 )) && _lp_escape "$branch"
+    if [ $? -eq 0 ]; then
+        local bookmark
+        bookmark="$(hg bookmarks -ql . 2>/dev/null)"
+        [ "z$bookmark" != 'z' ] && branch="$branch/$bookmark"
+    fi
+    _lp_escape "$branch"
 }
 
 # Set a color depending on the branch state:


### PR DESCRIPTION
I would like to propose this new version of #403. Instead of using sed around a mercurial command, it directly use the output of a well crafted mercurial command, what seems to be a bit more logical? I may have missed some things, as I’m not an heavy user of mercurial…