### PR TITLE
Ignore errors during sensors

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -1511,7 +1511,7 @@ if (( LP_ENABLE_TEMP )); then
         # Only the integer part is retained
         local -i i
         local IFS=$' \t\n'
-        for i in $(sensors -u |
+        for i in $(sensors -u 2>/dev/null |
                 sed -n 's/^  temp[0-9][0-9]*_input: \([0-9]*\)\..*$/\1/p'); do
             (( $i > ${temperature:-0} )) && temperature=i
         done


### PR DESCRIPTION
Due to a [recent CVE](https://nvd.nist.gov/vuln/detail/CVE-2020-12912), Linux now disables some modern sensor interfaces starting with 5.9.8. This in effect makes the output of sensors contain many of these:
```
ERROR: Can't get value of subfeature energy17_input: Kernel interface error
ERROR: Can't get value of subfeature energy18_input: Kernel interface error
ERROR: Can't get value of subfeature energy19_input: Kernel interface error
ERROR: Can't get value of subfeature energy20_input: Kernel interface error
ERROR: Can't get value of subfeature energy21_input: Kernel interface error
ERROR: Can't get value of subfeature energy22_input: Kernel interface error
ERROR: Can't get value of subfeature energy23_input: Kernel interface error
ERROR: Can't get value of subfeature energy24_input: Kernel interface error
ERROR: Can't get value of subfeature energy25_input: Kernel interface error
ERROR: Can't get value of subfeature energy26_input: Kernel interface error
ERROR: Can't get value of subfeature energy27_input: Kernel interface error
ERROR: Can't get value of subfeature energy28_input: Kernel interface error
```
I think the most useful approach to combat this is to use ignore the errors in the output of `sensors`.