### PR TITLE
Fix usage of POWERLINE_PYTHON_ENV_MARKER

### DIFF
--- a/themes/powerline/powerline.theme
+++ b/themes/powerline/powerline.theme
@@ -73,7 +73,7 @@ _lp_powerline_theme_prompt() {
 
     local lp_python_env
     if _lp_python_env; then
-        __powerline_section "(e) ${lp_python_env}" "${POWERLINE_PYTHON_ENV_COLOR[@]}"
+        __powerline_section "${POWERLINE_PYTHON_ENV_MARKER}${lp_python_env}" "${POWERLINE_PYTHON_ENV_COLOR[@]}"
     fi
 
     __powerline_path_section


### PR DESCRIPTION
Make the powerline theme respect the python env marker configured in
POWERLINE_PYTHON_ENV_MARKER variable instead of hardcoding it to '(e) '.
This works as intended in powerline_full theme.

------
Steps to reproduce the bug:
Setup
```
bash> python3 -m venv lp-venv-test
bash> . liquidprompt
1d [:~/dev/liquidprompt] master* $ POWERLINE_PYTHON_ENV_MARKER="[my-marker] "
```

Activate powerline theme and see that when activating python venv, the marker is `(e) `:

```
1d [:~/dev/liquidprompt] master* $ . themes/powerline/powerline.theme
1d [:~/dev/liquidprompt] master* $ lp_theme powerline
 ~  dev  liquidprompt   master  
 ~  dev  liquidprompt   master  . lp-venv-test/bin/activate
 (e) lp-venv-test  ~  dev  liquidprompt   master  
```

Activate powerline_full theme and see that marker `[my-marker] ` comes from the setting variable above:

```
 (e) lp-venv-test  ~  dev  liquidprompt   master  lp_theme powerline_full
 1d  ~  dev  liquidprompt  [my-marker] lp-venv-test  master*  
```

Checkout branch with fix, source and acticate powerline and see the env marker changed as expected:

```
 1d  ~  dev  liquidprompt  [my-marker] lp-venv-test  bugfix/powerline-python-env-marker*  lp_theme default
 1d [:~/dev/liquidprompt] [lp-venv-test] bugfix/powerline-python-env-marker* $ git checkout bugfix/powerline-python-env-marker
Switched to branch 'bugfix/powerline-python-env-marker'
1d [:~/dev/liquidprompt] [lp-venv-test] bugfix/powerline-python-env-marker* $ . themes/powerline/powerline.theme
1d [:~/dev/liquidprompt] [lp-venv-test] bugfix/powerline-python-env-marker* $ lp_theme powerline
 [my-marker] lp-venv-test  ~  dev  liquidprompt   bugfix/powerline-python-env-marker  
```