### PR TITLE
Add manual page generation to Sphinx docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+on:
+  push:
+    tags:
+    - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+
+name: Create Release With Assets
+
+jobs:
+  build:
+    name: Upload Release Asset
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+      - name: Build project
+        run: |
+          cd docs/
+          python3 -m pip install -r requirements.txt
+          make man
+          cd _build/
+          zip -r liquidprompt.man.zip man/
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: true
+          prerelease: false
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./docs/_build/liquidprompt.man.zip
+          asset_name: liquidprompt.man.zip
+          asset_content_type: application/zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,9 @@ jobs:
           release_name: Release ${{ github.ref }}
           draft: true
           prerelease: false
+      - name: Get the tag name
+        id: tag_name
+        run: echo ::set-output name=tag::${GITHUB_REF#refs/tags/}
       - name: Upload Release Asset
         uses: actions/upload-release-asset@v1
         env:
@@ -45,5 +48,5 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./.output/liquidprompt.tar.gz
-          asset_name: liquidprompt-${{ github.ref }}.tar.gz
+          asset_name: liquidprompt-${{ steps.tag_name.outputs.tag }}.tar.gz
           asset_content_type: application/gzip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,13 +18,16 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: '3.x'
-      - name: Build project
-        run: |
-          cd docs/
-          python3 -m pip install -r requirements.txt
-          make man
-          cd _build/
-          zip -r liquidprompt.man.zip man/
+      - name: Install Python dependencies
+        working-directory: ./docs
+        run: python3 -m pip install -r requirements.txt
+      - name: Build manual pages
+        working-directory: ./docs
+        run: make man
+      - name: Create output directory
+        run: mkdir -v ./.output
+      - name: Create release tarball
+        run: tar --exclude-vcs --exclude='./.*' --transform 's/^\./liquidprompt/' -zcvf ./.output/liquidprompt.tar.gz .
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -36,12 +39,11 @@ jobs:
           draft: true
           prerelease: false
       - name: Upload Release Asset
-        id: upload-release-asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./docs/_build/liquidprompt.man.zip
-          asset_name: liquidprompt.man.zip
-          asset_content_type: application/zip
+          asset_path: ./.output/liquidprompt.tar.gz
+          asset_name: liquidprompt-${{ github.ref }}.tar.gz
+          asset_content_type: application/gzip

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,8 +32,12 @@ extensions = [
     'sphinx_rtd_theme',
 ]
 
-# Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+# This value determines how to group the document tree into manual pages
+man_pages = [
+    ('functions', 'liquidprompt', 'Liquidprompt functions', [], 3),
+    ('config', 'liquidprompt', 'Liquidprompt configuration', [], 5),
+    ('theme', 'liquidprompt', 'Liquidprompt theming', [], 7),
+]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/theme.rst
+++ b/docs/theme.rst
@@ -1,16 +1,6 @@
 Theming
 *******
 
-.. toctree::
-   :maxdepth: 2
-
-   theme/default
-   theme/included
-   theme/custom
-
-.. contents::
-   :local:
-
 Liquidprompt has a strong data and theming engine, allowing it to be extremely
 flexible and customizable.
 
@@ -26,6 +16,16 @@ See the `Liquidprompt Theme List`_ on the wiki for user created themes.
 If you want to create your own theme, see :doc:`theme/custom`.
 
 .. _`Liquidprompt Theme List`: https://github.com/nojhan/liquidprompt/wiki/Themes
+
+.. toctree::
+   :maxdepth: 2
+
+   theme/default
+   theme/included
+   theme/custom
+
+.. contents::
+   :local:
 
 Switching Themes
 ----------------


### PR DESCRIPTION
Add mappings for config, functions, and theme to manual page sections. Install does not have a mapping, mostly because to get the manual pages you already need to have installed Liquidprompt. Though that does leave out how to install Liquidprompt into the shell. But maybe it is something that packages should include instructions for, since each package installs `liquidprompt` and the example config files to different locations.

Attached is a gzip of the compiled man pages: [liquidprompt.man.tar.gz](https://github.com/nojhan/liquidprompt/files/5704986/liquidprompt.man.tar.gz)

CC: @aborrero, @augmentedfourth

Any ideas of how to ship these files?