### PR TITLE
escape IFS character

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -1955,7 +1955,7 @@ case "$LP_OS" in
     _lp_battery() {
         (( LP_ENABLE_BATT )) || return 5
         local percent batt_status
-        IFS=; read -r lp_battery batt_status <<<"$(pmset -g batt | sed -n 's/^ -InternalBattery.*[[:space:]]\([0-9]*[0-9]\)%; \([^;]*\).*$/\1;\2/p')"
+        IFS=';' read -r lp_battery batt_status <<<"$(pmset -g batt | sed -n 's/^ -InternalBattery.*[[:space:]]\([0-9]*[0-9]\)%; \([^;]*\).*$/\1;\2/p')"
         case "$batt_status" in
             charged | "")
             return 4


### PR DESCRIPTION
Shell: bash 3.2.57 (1) -release (x86_64-apple-darwin20)
Operating system: macOS Big Sur
Liquidprompt version: 298693e1e3c091d79aba5d5adf302800766cd8ae

When I updated the liquidprompt, I got an error, so I fixed it.

Error messages:
```
⌁95;charging% [raina_otoni:~] 258 $
-bash: ((: 95;charging: syntax error: invalid arithmetic operator (error token is ";charging")
-bash: ((: 95;charging: syntax error: invalid arithmetic operator (error token is ";charging")
-bash: ((: 95;charging: syntax error: invalid arithmetic operator (error token is ";charging")
```