### PR TITLE
Update liquidprompt-dist for a local rcfile

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -31,6 +31,15 @@ start from this file for your config::
 
     cp ~/liquidprompt/liquidpromptrc-dist ~/.config/liquidpromptrc
 
+In the event that you synchronize your configuration file across multiple
+computers, or if you have an ``/etc/liquidpromptrc`` system-wide from which
+you'd like to make minor deviations in an individual user account, you can
+augment the primary config to add in any local modifications using lines such
+as these::
+
+    LOCAL_RCFILE=$HOME/.liquidpromptrc.local
+    [ -f "$LOCAL_RCFILE" ] && source "$LOCAL_RCFILE"
+
 .. note::
    The example config file does not include every config option, and the
    comments describing the options are less verbose than the descriptions on

--- a/liquidpromptrc-dist
+++ b/liquidpromptrc-dist
@@ -181,4 +181,11 @@ LP_ENABLE_ERROR=1
 # Ex: ("/root" "/home/me/large-remove-svn-repo")
 LP_DISABLED_VCS_PATHS=()
 
+# Use a local liquidpromptrc if it exists.
+# Can be helpful if you sync your primary config across machines, or if
+# there's a system-wide config at /etc/liquidpromptrc from which you'd
+# like to make only minor deviations.
+#LOCAL_RCFILE=$HOME/.liquidpromptrc.local
+#[ -f "$LOCAL_RCFILE" ] && source "$LOCAL_RCFILE"
+
 # vim: set et sts=4 sw=4 tw=120 ft=sh:


### PR DESCRIPTION
This may or may not be useful, but wanted to propose the idea. And the implementation is probably sub-optimal.

I use a file sync to keep my `.liquidpromptrc` the same on all my hosts, but on a couple of the individual machines I want to change/add config, so I added this.

is this worth merging/suggesting to users? Or maybe `liquidprompt` itself should source multiple configs? So I could sync `~/.liquidpromptrc` as the "main" config but include local, subsidiary configs from `~/.config/liquidpromptrc`? I know that changes things a lot from how it's documented, though.