### PR TITLE
Feature/vcs staging

### DIFF
--- a/docs/functions/data/vcs.rst
+++ b/docs/functions/data/vcs.rst
@@ -129,6 +129,26 @@ this.
 
    .. versionadded:: 2.0
 
+.. function:: _lp_vcs_staged_files() -> var:lp_vcs_staged_files
+
+   Returns ``true`` if any staged files exist in the repository. In other words,
+   tracked files that contain staged changes. Returns the number of staged
+   files.
+
+   Many VCS providers do not support staging.
+
+   .. versionadded:: 2.0
+
+.. function:: _lp_vcs_staged_lines() -> var:lp_vcs_staged_i_lines, var:lp_vcs_staged_d_lines
+
+   Returns ``true`` if any staged lines exist in the repository. In other words,
+   tracked files that contain staged changes. Returns the number of staged
+   lines.
+
+   Many VCS providers do not support staging.
+
+   .. versionadded:: 2.0
+
 .. function:: _lp_vcs_stash_count() -> var:lp_vcs_stash_count
 
    Returns ``true`` if there are stashes the repository. Returns the
@@ -435,6 +455,22 @@ Git
    Return ``true`` if the repository is in a special or unusual state. Return
    the special status, and any extra details (like progress in a rebase) if
    applicable.
+
+   .. versionadded:: 2.0
+
+.. function:: _lp_git_staged_files() -> var:lp_vcs_staged_files
+
+   Returns ``true`` if any staged files exist in the repository. In other words,
+   tracked files that contain staged changes. Returns the number of staged
+   files.
+
+   .. versionadded:: 2.0
+
+.. function:: _lp_git_staged_lines() -> var:lp_vcs_staged_i_lines, var:lp_vcs_staged_d_lines
+
+   Returns ``true`` if any staged lines exist in the repository. In other words,
+   tracked files that contain staged changes. Returns the number of staged
+   lines.
 
    .. versionadded:: 2.0
 

--- a/docs/functions/internal.rst
+++ b/docs/functions/internal.rst
@@ -54,6 +54,47 @@ Formatting
 
 .. _`ANSI escape color code`: https://en.wikipedia.org/wiki/ANSI_escape_code#Colors
 
+Git
+---
+
+.. function:: __lp_git_diff_shortstat_files(diff_shortstat) -> var:lp_git_diff_shortstat_files
+
+   Processes the input *diff_shortstat* as the output of a ``git diff
+   --shortstat`` command, returning the number of changed files. This allows for
+   the comparison of any two states, as :func:`__lp_git_diff_shortstat_files`
+   does not run any specific ``git diff`` command.
+
+   .. versionadded:: 2.0
+
+.. function:: __lp_git_diff_shortstat_lines(diff_shortstat) -> var:lp_git_diff_shortstat_lines
+
+   Processes the input *diff_shortstat* as the output of a ``git diff
+   --shortstat`` command, returning the number of changed lines. This allows for
+   the comparison of any two states, as :func:`__lp_git_diff_shortstat_files`
+   does not run any specific ``git diff`` command.
+
+   .. versionadded:: 2.0
+
+.. function:: __lp_git_diff_shortstat_uncommitted() -> var:_lp_git_diff_shortstat_uncommitted
+
+   Returns the output of a ``git diff --shortstat`` command, comparing the
+   working directory to the HEAD commit.
+
+   The return variable is supposed to be a cache, set as local in
+   :func:`__lp_set_prompt`, preventing duplicate calls to ``git``.
+
+   .. versionadded:: 2.0
+
+.. function:: __lp_git_diff_shortstat_unstaged() -> var:_lp_git_diff_shortstat_unstaged
+
+   Returns the output of a ``git diff --shortstat`` command, comparing the
+   working directory to the staging area.
+
+   The return variable is supposed to be a cache, set as local in
+   :func:`__lp_set_prompt`, preventing duplicate calls to ``git``.
+
+   .. versionadded:: 2.0
+
 Load
 ----
 
@@ -129,8 +170,8 @@ Prompt
    Setup features that need to be handled outside of the themes, like
    :func:`_lp_error` (since last return code must be recorded first), non
    printing features like :attr:`LP_ENABLE_RUNTIME_BELL` and
-   :attr:`LP_ENABLE_TITLE`, and track current directory changes. This function
-   also calls the current theme functions.
+   :attr:`LP_ENABLE_TITLE`, track current directory changes, and initialize data
+   source cache variables. This function also calls the current theme functions.
 
    .. versionchanged:: 2.0
       Renamed from ``_lp_set_prompt``.

--- a/docs/functions/internal.rst
+++ b/docs/functions/internal.rst
@@ -75,6 +75,16 @@ Git
 
    .. versionadded:: 2.0
 
+.. function:: __lp_git_diff_shortstat_staged() -> var:_lp_git_diff_shortstat_staged
+
+   Returns the output of a ``git diff --shortstat`` command, comparing the
+   staging area to the HEAD commit.
+
+   The return variable is supposed to be a cache, set as local in
+   :func:`__lp_set_prompt`, preventing duplicate calls to ``git``.
+
+   .. versionadded:: 2.0
+
 .. function:: __lp_git_diff_shortstat_uncommitted() -> var:_lp_git_diff_shortstat_uncommitted
 
    Returns the output of a ``git diff --shortstat`` command, comparing the

--- a/liquidprompt
+++ b/liquidprompt
@@ -1387,6 +1387,16 @@ _lp_vcs_unstaged_lines() {
     "_lp_${lp_vcs_type}_unstaged_lines" 2>/dev/null
 }
 
+# Get the number of changed files in staging compared to the last or checked out commit.
+_lp_vcs_staged_files() {
+    "_lp_${lp_vcs_type}_staged_files" 2>/dev/null
+}
+
+# Get the number of changed lines in staging compared to the last or checked out commit.
+_lp_vcs_staged_lines() {
+    "_lp_${lp_vcs_type}_staged_lines" 2>/dev/null
+}
+
 # GIT #
 
 # Check if Git is enabled in Liquidprompt and the current directory is a valid
@@ -1574,6 +1584,33 @@ _lp_git_unstaged_lines() {
 
     lp_vcs_unstaged_i_lines=$lp_git_diff_shortstat_i_lines
     lp_vcs_unstaged_d_lines=$lp_git_diff_shortstat_d_lines
+}
+
+__lp_git_diff_shortstat_staged() {
+    if [[ -z ${_lp_git_diff_shortstat_staged+x} ]]; then
+        _lp_git_diff_shortstat_staged="$(LC_ALL=C \git diff --shortstat --cached 2>/dev/null)"
+    fi
+}
+
+# Get the number of changed files in staging compared to HEAD.
+_lp_git_staged_files() {
+    __lp_git_diff_shortstat_staged
+
+    local lp_git_diff_shortstat_files
+    __lp_git_diff_shortstat_files "$_lp_git_diff_shortstat_staged" || return "$?"
+
+    lp_vcs_staged_files=$lp_git_diff_shortstat_files
+}
+
+# Get the number of changed lines in staging compared to HEAD.
+_lp_git_staged_lines() {
+    __lp_git_diff_shortstat_staged
+
+    local lp_git_diff_shortstat_i_lines lp_git_diff_shortstat_d_lines
+    __lp_git_diff_shortstat_lines "$_lp_git_diff_shortstat_staged" || return "$?"
+
+    lp_vcs_staged_i_lines=$lp_git_diff_shortstat_i_lines
+    lp_vcs_staged_d_lines=$lp_git_diff_shortstat_d_lines
 }
 
 # MERCURIAL #
@@ -2554,7 +2591,7 @@ __lp_set_prompt() {
     fi
 
     # Localize cache data variables
-    local _lp_git_diff_shortstat_uncommitted _lp_git_diff_shortstat_unstaged
+    local _lp_git_diff_shortstat_uncommitted _lp_git_diff_shortstat_unstaged _lp_git_diff_shortstat_staged
 
     # if change of working directory
     if [[ "${LP_OLD_PWD-}" != "LP:$PWD" ]]; then

--- a/liquidprompt
+++ b/liquidprompt
@@ -1488,76 +1488,92 @@ _lp_git_untracked_files() {
     (( lp_vcs_untracked_files ))
 }
 
-# Get the number of changed files compared to HEAD.
-_lp_git_uncommitted_files() {
-    local stat
-    stat="$(LC_ALL=C \git diff --shortstat HEAD -- 2>/dev/null)"
+# Get the number of changed files.
+__lp_git_diff_shortstat_files() {  # diff_shortstat
+    local stat=$1
 
     if [[ "$stat" = *changed* ]]; then
         stat="${stat/ file*}"
-        lp_vcs_uncommitted_files=${stat//[$' \t']}
+        lp_git_diff_shortstat_files=${stat//[$' \t']}
     else
         return 1
     fi
+}
+
+# Get the number of changed lines.
+__lp_git_diff_shortstat_lines() {  # diff_shortstat
+    local stat=$1
+
+    stat=${stat/*changed, /} # removing "n file(s) changed"
+
+    if [[ "$stat" = *insertion* ]]; then
+        lp_git_diff_shortstat_i_lines=${stat/ inser*}
+    else
+        lp_git_diff_shortstat_i_lines=0
+    fi
+
+    if [[ "$stat" = *deletion* ]]; then
+        stat=${stat/*\(+\), }
+        lp_git_diff_shortstat_d_lines=${stat/ del*/}
+    else
+        lp_git_diff_shortstat_d_lines=0
+    fi
+
+    (( lp_git_diff_shortstat_i_lines || lp_git_diff_shortstat_d_lines ))
+}
+
+__lp_git_diff_shortstat_uncommitted() {
+    if [[ -z ${_lp_git_diff_shortstat_uncommitted+x} ]]; then
+        _lp_git_diff_shortstat_uncommitted="$(LC_ALL=C \git diff --shortstat HEAD -- 2>/dev/null)"
+    fi
+}
+
+# Get the number of changed files compared to HEAD.
+_lp_git_uncommitted_files() {
+    __lp_git_diff_shortstat_uncommitted
+
+    local lp_git_diff_shortstat_files
+    __lp_git_diff_shortstat_files "$_lp_git_diff_shortstat_uncommitted" || return "$?"
+
+    lp_vcs_uncommitted_files=$lp_git_diff_shortstat_files
 }
 
 # Get the number of changed lines compared to HEAD.
 _lp_git_uncommitted_lines() {
-    local stat
-    stat="$(LC_ALL=C \git diff --shortstat HEAD -- 2>/dev/null)"
+    __lp_git_diff_shortstat_uncommitted
 
-    stat=${stat/*changed, /} # removing "n file(s) changed"
+    local lp_git_diff_shortstat_i_lines lp_git_diff_shortstat_d_lines
+    __lp_git_diff_shortstat_lines "$_lp_git_diff_shortstat_uncommitted" || return "$?"
 
-    if [[ "$stat" = *insertion* ]]; then
-        lp_vcs_uncommitted_i_lines=${stat/ inser*}
-    else
-        lp_vcs_uncommitted_i_lines=0
+    lp_vcs_uncommitted_i_lines=$lp_git_diff_shortstat_i_lines
+    lp_vcs_uncommitted_d_lines=$lp_git_diff_shortstat_d_lines
+}
+
+__lp_git_diff_shortstat_unstaged() {
+    if [[ -z ${_lp_git_diff_shortstat_unstaged+x} ]]; then
+        _lp_git_diff_shortstat_unstaged="$(LC_ALL=C \git diff --shortstat 2>/dev/null)"
     fi
-
-    if [[ "$stat" = *deletion* ]]; then
-        stat=${stat/*\(+\), }
-        lp_vcs_uncommitted_d_lines=${stat/ del*/}
-    else
-        lp_vcs_uncommitted_d_lines=0
-    fi
-
-    (( lp_vcs_uncommitted_i_lines || lp_vcs_uncommitted_d_lines ))
 }
 
 # Get the number of changed files compared to staging.
 _lp_git_unstaged_files() {
-    local stat
-    stat="$(LC_ALL=C \git diff --shortstat 2>/dev/null)"
+    __lp_git_diff_shortstat_unstaged
 
-    if [[ "$stat" = *changed* ]]; then
-        stat="${stat/ file*}"
-        lp_vcs_unstaged_files=${stat//[$' \t']}
-    else
-        return 1
-    fi
+    local lp_git_diff_shortstat_files
+    __lp_git_diff_shortstat_files "$_lp_git_diff_shortstat_unstaged" || return "$?"
+
+    lp_vcs_unstaged_files=$lp_git_diff_shortstat_files
 }
 
 # Get the number of changed lines compared to staging.
 _lp_git_unstaged_lines() {
-    local stat
-    stat="$(LC_ALL=C \git diff --shortstat 2>/dev/null)"
+    __lp_git_diff_shortstat_unstaged
 
-    stat=${stat/*changed, /} # removing "n file(s) changed"
+    local lp_git_diff_shortstat_i_lines lp_git_diff_shortstat_d_lines
+    __lp_git_diff_shortstat_lines "$_lp_git_diff_shortstat_unstaged" || return "$?"
 
-    if [[ "$stat" = *insertion* ]]; then
-        lp_vcs_unstaged_i_lines=${stat/ inser*}
-    else
-        lp_vcs_unstaged_i_lines=0
-    fi
-
-    if [[ "$stat" = *deletion* ]]; then
-        stat=${stat/*\(+\), }
-        lp_vcs_unstaged_d_lines=${stat/ del*/}
-    else
-        lp_vcs_unstaged_d_lines=0
-    fi
-
-    (( lp_vcs_unstaged_i_lines || lp_vcs_unstaged_d_lines ))
+    lp_vcs_unstaged_i_lines=$lp_git_diff_shortstat_i_lines
+    lp_vcs_unstaged_d_lines=$lp_git_diff_shortstat_d_lines
 }
 
 # MERCURIAL #
@@ -2536,6 +2552,9 @@ __lp_set_prompt() {
     if (( LP_ENABLE_RUNTIME_BELL && _LP_RUNTIME_SECONDS >= LP_RUNTIME_BELL_THRESHOLD )); then
         printf '%s' "$_LP_TI_BELL"
     fi
+
+    # Localize cache data variables
+    local _lp_git_diff_shortstat_uncommitted _lp_git_diff_shortstat_unstaged
 
     # if change of working directory
     if [[ "${LP_OLD_PWD-}" != "LP:$PWD" ]]; then


### PR DESCRIPTION
Adds `git_staged_files()` and `git_staged_lines()`.

Also includes a commit to add caching to the output of the `git diff --shortstat` commands, to speedup calls to both `*_lines()` and the related `*_files()` git calls on the same prompt build. I'm not completely sold on it yet, but it does work without speed reductions.

Fixes #644