### PR TITLE
Feature/path format

### DIFF
--- a/docs/functions/data.rst
+++ b/docs/functions/data.rst
@@ -274,6 +274,47 @@ OS
 
    .. versionadded:: 2.0
 
+Path
+----
+
+.. function:: _lp_path_format(path_format=$LP_COLOR_PATH, \
+   last_directory_format=$path_format, vcs_root_format=$last_directory_format, \
+   shortened_directory_format=$path_format, separator="/", \
+   [separator_format]) -> var:lp_path, var:lp_path_format
+
+   Returns a shortened and formatted string indicating the current working
+   directory path. *lp_path* contains the path without any formatting or custom
+   separators, intended for use in the terminal title. *lp_path_format* contains
+   the complete formatted path, to be inserted into the prompt.
+
+   The behavior of the shortening is controlled by
+   :attr:`LP_ENABLE_SHORTEN_PATH`, :attr:`LP_PATH_METHOD`,
+   :attr:`LP_PATH_LENGTH`, :attr:`LP_PATH_KEEP`, :attr:`LP_PATH_CHARACTER_KEEP`,
+   and :attr:`LP_PATH_VCS_ROOT`. See their descriptions for details on how they
+   change the output of this function.
+
+   The last directory in the displayed path will be shown with the
+   *last_directory_format*.
+
+   If a VCS repository is detected with :func:`_lp_find_vcs`, the root of the
+   VCS repository is formatted with *vcs_root_format*. The detection method is
+   the same as for all other VCS display, so if a VCS type or directory is
+   disabled, it will not be detected.
+
+   If the path shortening shortens a directory (or multiple consecutive
+   directories), they will be formatted with *shortened_directory_format*.
+
+   A custom *separator* will only be substituted in the *lp_path_format* output.
+   Note that this will cut into maximum path length if the separator is longer
+   than one character.
+
+   With no specified *separator_format*, each separator will take the format of
+   the directory section preceding it. Otherwise every separator will be
+   formatted with *separator_format*. Note that the root directory is treated as
+   a directory, and is formatted as such.
+
+   .. versionadded:: 2.0
+
 Runtime
 -------
 

--- a/docs/functions/internal.rst
+++ b/docs/functions/internal.rst
@@ -127,50 +127,30 @@ OS
 Path
 ----
 
-.. function:: __lp_path() -> var:lp_path
+.. function:: __lp_end_path_left_shortening()
 
-   Sets :attr:`lp_path` to the current path. Internally, calls either
-   :func:`__lp_shorten_path` or :func:`__lp_set_dirtrim` to do so, depending on
-   the values of :attr:`LP_PATH_KEEP` and :attr:`LP_ENABLE_SHORTEN_PATH`.
-
-   Only :func:`__lp_shorten_path` actually sets ``lp_path``, other config
-   options will initialize ``lp_path`` with a shell escape sequence so the
-   shell will print the path.
+   Terminate a multi-directory shortening, checking if the shortening actually
+   made a shorter path, and if so, adding the shortened mark. If not, adds the
+   real path to the output. Only used internally by :func:`_lp_path_format`.
 
    .. versionadded:: 2.0
 
-.. function:: __lp_pwd_tilde() -> var:lp_pwd_tilde
+.. function:: __lp_get_unique_directory(path) -> var:lp_unique_directory
 
-   Returns :envvar:`PWD` with the user's home directory replace with a tilde
-   ("~").
+   Returns the shortest unique directory prefix matching the real directory
+   input. Only used internally by :func:`_lp_path_format`.
+
+   .. versionadded:: 2.0
+
+.. function:: __lp_pwd_tilde([path]) -> var:lp_pwd_tilde
+
+   Returns *path*, or :envvar:`PWD` if *path* is not set, with the user's home
+   directory replaced with a tilde ("~").
 
    .. versionchanged:: 2.0
       Renamed from ``_lp_get_home_tilde_collapsed``.
       Return method changed from stdout.
-
-.. function:: __lp_set_dirtrim() -> var:PROMPT_DIRTRIM
-
-   In Bash shells, :envvar:`PROMPT_DIRTRIM` is the number of directories to keep
-   at the end of the displayed path (if "\w" is present in :envvar:`PS1`).
-   Liquid Prompt can calculate this number under two conditions, path shortening
-   must be disabled and :envvar:`PROMPT_DIRTRIM` must be already set.
-
-   .. versionchanged:: 2.0
-      Renamed from ``_lp_set_dirtrim``.
-
-.. function:: __lp_shorten_path() -> var:lp_shorten_path
-
-   Shorten the path of the current working directory if the path is longer than
-   :attr:`LP_PATH_LENGTH`. Show as much of the current working directory path as
-   possible. If shortened display a leading mark, such as ellipses, to indicate
-   that part is missing. Show at least :attr:`LP_PATH_KEEP` leading directories
-   and current directory.
-
-   .. versionchanged:: 2.0
-      Renamed from ``_lp_shorten_path``.
-      Removed handling of cases where no shortening is required, as that should
-      be handled by :attr:`__lp_path` on activate.
-      Return variable changed from ``LP_PWD``.
+      Optional parameter *path* added.
 
 Prompt
 ------

--- a/docs/theme/included/powerline.rst
+++ b/docs/theme/included/powerline.rst
@@ -203,6 +203,22 @@ These color config options take an array of integers, which are arguments to
 
    Color for the current working directory subsection separator.
 
+.. attribute:: POWERLINE_PATH_SHORTENED_COLOR
+   :type: array<int>
+   :value: (245, 240, 0, 0, 7, 0)
+
+   Color for any sections in the current working directory that are shortened to
+   make the path fit in :attr:`LP_PATH_LENGTH`.
+
+.. attribute:: POWERLINE_PATH_VCS_COLOR
+   :type: array<int>
+   :value: (147, 240, 1, 0, 4, 0)
+
+   Color for the current working directory segment corresponding to the current
+   VCS repository root directory.
+
+   :attr:`LP_PATH_VCS_ROOT` must be enabled to have any effect.
+
 .. attribute:: POWERLINE_PYTHON_ENV_COLOR
    :type: array<int>
    :value: (231, 74, 0, 0, 7, 4)

--- a/liquidprompt
+++ b/liquidprompt
@@ -180,6 +180,7 @@ __lp_source_config() {
     LP_RUNTIME_BELL_THRESHOLD=${LP_RUNTIME_BELL_THRESHOLD:-10}
     LP_PATH_LENGTH=${LP_PATH_LENGTH:-35}
     LP_PATH_KEEP=${LP_PATH_KEEP:-2}
+    LP_PATH_METHOD=${LP_PATH_METHOD:-truncate_chars_from_path_left}
     LP_PATH_VCS_ROOT=${LP_PATH_VCS_ROOT:-1}
     LP_PATH_DEFAULT="${LP_PATH_DEFAULT:-$_LP_PWD_SYMBOL}"
     LP_HOSTNAME_ALWAYS=${LP_HOSTNAME_ALWAYS:-0}
@@ -757,6 +758,12 @@ __lp_get_unique_directory() {
     return 1
 }
 
+# methods:
+#   truncate_chars_from_path_left
+#   truncate_chars_from_dir_middle
+#   truncate_chars_from_dir_right
+#   truncate_chars_to_unique_dir
+#   dirs_from_path_right
 _lp_path_format() {
     local path_format=${1-$LP_COLOR_PATH}
     local last_directory_format=${2:-$path_format}
@@ -787,6 +794,7 @@ _lp_path_format() {
         fi
     else
         # only root or home to show
+        # TODO this does not show if root or home is vcs
         lp_path=$display_path
         lp_path_format="${last_directory_format}${display_path}"
         return
@@ -801,7 +809,7 @@ _lp_path_format() {
 
     local path_to_proccess="${display_path}/" current_path="" current_directory="" lp_unique_directory
 
-    local -i max_len=$(( ${COLUMNS:-80} * LP_PATH_LENGTH / 100 )) directory_count=0
+    local -i max_len=$(( ${COLUMNS:-80} * LP_PATH_LENGTH / 100 )) directory_count=0 needed_length
     local shortened_path_length=$path_length
 
     while [[ -n $path_to_proccess ]]; do
@@ -826,11 +834,40 @@ _lp_path_format() {
         elif [[ -z $path_to_proccess ]]; then
             # Last directory
             lp_path_format+="${last_directory_format}${current_directory}"
-        elif (( shortened_path_length > max_len && directory_count > LP_PATH_KEEP )) && \
-            __lp_get_unique_directory "$current_path"; then
+        elif (( shortened_path_length > max_len && directory_count > LP_PATH_KEEP )); then
+            needed_length=$(( shortened_path_length - max_len ))
 
-            lp_path_format+="${shortened_directory_format}${lp_unique_directory}"
-            shortened_path_length=$(( shortened_path_length - ${#current_directory} + ${#lp_unique_directory} ))
+            if [[ $LP_PATH_METHOD == "truncate_chars_to_unique_dir" ]] && \
+                __lp_get_unique_directory "$current_path"; then
+
+                lp_path_format+="${shortened_directory_format}${lp_unique_directory}"
+                shortened_path_length=$(( shortened_path_length - ${#current_directory} + ${#lp_unique_directory} ))
+            elif [[ $LP_PATH_METHOD == "truncate_chars_from_path_left" ]] && \
+                (( ${#LP_MARK_SHORTEN_PATH} < ${#current_directory} )); then
+
+                lp_path_format+="${shortened_directory_format}${LP_MARK_SHORTEN_PATH}"
+
+                if (( needed_length >= ${#current_directory} )); then
+                    shortened_path_length=$(( shortened_path_length - ${#current_directory} ))
+                else
+                    lp_path_format+="${current_directory:$needed_length}"
+                    shortened_path_length=$(( shortened_path_length - needed_length ))
+                fi
+            elif [[ $LP_PATH_METHOD == "truncate_chars_from_dir_right" ]] && \
+                (( ${#LP_MARK_SHORTEN_PATH} + 3 < ${#current_directory} )); then
+
+                lp_path_format+="${shortened_directory_format}${current_directory:0:3}${LP_MARK_SHORTEN_PATH}"
+                shortened_path_length=$(( shortened_path_length - ${#current_directory} + ${#LP_MARK_SHORTEN_PATH} + 3 ))
+            elif [[ $LP_PATH_METHOD == "truncate_chars_from_dir_middle" ]] && \
+                (( ${#LP_MARK_SHORTEN_PATH} + 6 < ${#current_directory} )); then
+
+                lp_path_format+="${shortened_directory_format}${current_directory:0:3}${LP_MARK_SHORTEN_PATH}${current_directory: -3}"
+                shortened_path_length=$(( shortened_path_length - ${#current_directory} + ${#LP_MARK_SHORTEN_PATH} + 6 ))
+            else
+                # Need to shorten, but no method matched, or the matched method
+                # did not make the string any shorter.
+                lp_path_format+="${path_format}${current_directory}"
+            fi
         else
             lp_path_format+="${path_format}${current_directory}"
         fi

--- a/liquidprompt
+++ b/liquidprompt
@@ -180,6 +180,7 @@ __lp_source_config() {
     LP_RUNTIME_BELL_THRESHOLD=${LP_RUNTIME_BELL_THRESHOLD:-10}
     LP_PATH_LENGTH=${LP_PATH_LENGTH:-35}
     LP_PATH_KEEP=${LP_PATH_KEEP:-2}
+    LP_PATH_VCS_ROOT=${LP_PATH_VCS_ROOT:-1}
     LP_PATH_DEFAULT="${LP_PATH_DEFAULT:-$_LP_PWD_SYMBOL}"
     LP_HOSTNAME_ALWAYS=${LP_HOSTNAME_ALWAYS:-0}
     LP_USER_ALWAYS=${LP_USER_ALWAYS:-1}
@@ -793,7 +794,7 @@ _lp_path_format() {
 
     local lp_vcs_root lp_vcs_type
     local vcs_root_directory=
-    if _lp_find_vcs; then
+    if (( LP_PATH_VCS_ROOT )) && _lp_find_vcs; then
         __lp_pwd_tilde "$lp_vcs_root"
         vcs_root_directory=$lp_pwd_tilde
     fi

--- a/liquidprompt
+++ b/liquidprompt
@@ -801,7 +801,7 @@ _lp_path_format() {
 
     local path_to_proccess="${display_path}/" current_path="" current_directory="" lp_unique_directory
 
-    local -i max_len=$(( ${COLUMNS:-80} * LP_PATH_LENGTH / 100 ))
+    local -i max_len=$(( ${COLUMNS:-80} * LP_PATH_LENGTH / 100 )) directory_count=0
     local shortened_path_length=$path_length
 
     while [[ -n $path_to_proccess ]]; do
@@ -816,6 +816,7 @@ _lp_path_format() {
             fi
         fi
 
+        directory_count+=1
         current_path+=${current_directory}
         path_to_proccess=${path_to_proccess#*/}
 
@@ -825,7 +826,9 @@ _lp_path_format() {
         elif [[ -z $path_to_proccess ]]; then
             # Last directory
             lp_path_format+="${last_directory_format}${current_directory}"
-        elif (( shortened_path_length > max_len )) && __lp_get_unique_directory "$current_path"; then
+        elif (( shortened_path_length > max_len && directory_count > LP_PATH_KEEP )) && \
+            __lp_get_unique_directory "$current_path"; then
+
             lp_path_format+="${shortened_directory_format}${lp_unique_directory}"
             shortened_path_length=$(( shortened_path_length - ${#current_directory} + ${#lp_unique_directory} ))
         else

--- a/liquidprompt
+++ b/liquidprompt
@@ -180,6 +180,7 @@ __lp_source_config() {
     LP_RUNTIME_BELL_THRESHOLD=${LP_RUNTIME_BELL_THRESHOLD:-10}
     LP_PATH_LENGTH=${LP_PATH_LENGTH:-35}
     LP_PATH_KEEP=${LP_PATH_KEEP:-2}
+    LP_PATH_CHARACTER_KEEP=${LP_PATH_CHARACTER_KEEP:-3}
     LP_PATH_METHOD=${LP_PATH_METHOD:-truncate_chars_from_path_left}
     LP_PATH_VCS_ROOT=${LP_PATH_VCS_ROOT:-1}
     LP_PATH_DEFAULT="${LP_PATH_DEFAULT:-$_LP_PWD_SYMBOL}"
@@ -854,15 +855,16 @@ _lp_path_format() {
                     shortened_path_length=$(( shortened_path_length - needed_length ))
                 fi
             elif [[ $LP_PATH_METHOD == "truncate_chars_from_dir_right" ]] && \
-                (( ${#LP_MARK_SHORTEN_PATH} + 3 < ${#current_directory} )); then
+                (( ${#LP_MARK_SHORTEN_PATH} + LP_PATH_CHARACTER_KEEP < ${#current_directory} )); then
 
-                lp_path_format+="${shortened_directory_format}${current_directory:0:3}${LP_MARK_SHORTEN_PATH}"
-                shortened_path_length=$(( shortened_path_length - ${#current_directory} + ${#LP_MARK_SHORTEN_PATH} + 3 ))
+                lp_path_format+="${shortened_directory_format}${current_directory:0:$LP_PATH_CHARACTER_KEEP}${LP_MARK_SHORTEN_PATH}"
+                shortened_path_length=$(( shortened_path_length - ${#current_directory} + ${#LP_MARK_SHORTEN_PATH} + LP_PATH_CHARACTER_KEEP ))
             elif [[ $LP_PATH_METHOD == "truncate_chars_from_dir_middle" ]] && \
-                (( ${#LP_MARK_SHORTEN_PATH} + 6 < ${#current_directory} )); then
+                (( ${#LP_MARK_SHORTEN_PATH} + LP_PATH_CHARACTER_KEEP * 2 < ${#current_directory} )); then
 
-                lp_path_format+="${shortened_directory_format}${current_directory:0:3}${LP_MARK_SHORTEN_PATH}${current_directory: -3}"
-                shortened_path_length=$(( shortened_path_length - ${#current_directory} + ${#LP_MARK_SHORTEN_PATH} + 6 ))
+                lp_path_format+="${shortened_directory_format}${current_directory:0:$LP_PATH_CHARACTER_KEEP}"
+                lp_path_format+="${LP_MARK_SHORTEN_PATH}${current_directory: -$LP_PATH_CHARACTER_KEEP}"
+                shortened_path_length=$(( shortened_path_length - ${#current_directory} + ${#LP_MARK_SHORTEN_PATH} + LP_PATH_CHARACTER_KEEP * 2 ))
             else
                 # Need to shorten, but no method matched, or the matched method
                 # did not make the string any shorter.

--- a/liquidprompt
+++ b/liquidprompt
@@ -779,7 +779,7 @@ __lp_end_path_left_shortening() {
 #   truncate_chars_from_dir_middle
 #   truncate_chars_from_dir_right
 #   truncate_chars_to_unique_dir
-#   dirs_from_path_right
+#   truncate_to_last_dir
 _lp_path_format() {
     local path_format=${1-$LP_COLOR_PATH}
     local last_directory_format=${2:-$path_format}
@@ -797,7 +797,28 @@ _lp_path_format() {
 
     local -i path_length=${#display_path}
 
-    if [[ $path_length > 1 ]]; then
+    local lp_vcs_root lp_vcs_type
+    local vcs_root_directory=
+    if (( LP_PATH_VCS_ROOT )) && _lp_find_vcs; then
+        __lp_pwd_tilde "$lp_vcs_root"
+        vcs_root_directory=$lp_pwd_tilde
+    fi
+
+    if [[ $path_length == 1 || $LP_PATH_METHOD == "truncate_to_last_dir" ]]; then
+        if [[ $path_length > 1 ]]; then
+            lp_path=${display_path##*/}
+        else
+            # only root or home to show
+            lp_path=$display_path
+        fi
+
+        if [[ $display_path == $vcs_root_directory ]]; then
+            lp_path_format="${vcs_root_format}${lp_path}"
+        else
+            lp_path_format="${last_directory_format}${lp_path}"
+        fi
+        return
+    else
         if [[ $separator != "/" && ${display_path:0:1} == "/" ]]; then
             # The root directory ('/') becomes a directory name instead of a leading separator
             # Add one to account for the first / needing to be both replaced and shown
@@ -808,19 +829,6 @@ _lp_path_format() {
             local slash_count="${display_path//[!"/"]}"
             path_length+=$(( ${#slash_count} * ( ${#separator} - 1 ) ))
         fi
-    else
-        # only root or home to show
-        # TODO this does not show if root or home is vcs
-        lp_path=$display_path
-        lp_path_format="${last_directory_format}${display_path}"
-        return
-    fi
-
-    local lp_vcs_root lp_vcs_type
-    local vcs_root_directory=
-    if (( LP_PATH_VCS_ROOT )) && _lp_find_vcs; then
-        __lp_pwd_tilde "$lp_vcs_root"
-        vcs_root_directory=$lp_pwd_tilde
     fi
 
     local path_to_proccess="${display_path}/" current_path="" current_directory="" lp_unique_directory

--- a/liquidprompt
+++ b/liquidprompt
@@ -109,7 +109,7 @@ _LP_SED_EXTENDED=r
 # Load the user configuration and setup defaults.
 __lp_source_config() {
 
-    local af_color= ab_color=
+    local lp_terminal_format af_color= ab_color=
 
     # Colors: variables are local so they will have a value only
     # during config loading and will not conflict with other values
@@ -240,7 +240,14 @@ __lp_source_config() {
     LP_MARK_PERM="${LP_MARK_PERM:-":"}"
     LP_MARK_DIRSTACK="${LP_MARK_DIRSTACK:-"⚞"}"
 
-    LP_COLOR_PATH=${LP_COLOR_PATH:-$BOLD}
+    lp_terminal_format 255 0 0 0 7
+    LP_COLOR_PATH=${LP_COLOR_PATH:-$lp_terminal_format}
+    lp_terminal_format 245 0 0 0 7
+    LP_COLOR_PATH_SEPARATOR=${LP_COLOR_PATH_SEPARATOR:-$lp_terminal_format}
+    LP_COLOR_PATH_SHORTENED=${LP_COLOR_PATH_SHORTENED:-$lp_terminal_format}
+    lp_terminal_format 255 0 1 0 7
+    LP_COLOR_PATH_VCS_ROOT=${LP_COLOR_PATH_VCS_ROOT:-$lp_terminal_format}
+    LP_COLOR_PATH_LAST_DIR=${LP_COLOR_PATH_LAST_DIR:-$lp_terminal_format}
     LP_COLOR_PATH_ROOT=${LP_COLOR_PATH_ROOT:-$BOLD_YELLOW}
     LP_COLOR_PROXY=${LP_COLOR_PROXY:-$BOLD_BLUE}
     LP_COLOR_JOB_D=${LP_COLOR_JOB_D:-$YELLOW}
@@ -2565,22 +2572,8 @@ _lp_default_theme_directory() {
         fi
     fi
 
-    LP_PWD="${LP_COLOR_PATH}${lp_path}${NO_COL}"
-
-    local lp_terminal_format
-    lp_terminal_format 250 240 0 0 7 0
-    local path_format=$lp_terminal_format
-    lp_terminal_format 245 240 0 0 7 0
-    local short_format=$lp_terminal_format
-    lp_terminal_format 245 240 0 0 7 0
-    local separator_format=$lp_terminal_format
-    lp_terminal_format 147 240 0 0 4 0
-    local vcs_format=$lp_terminal_format
-    lp_terminal_format 255 240 1 0 7 0
-    local last_format=$lp_terminal_format
-
     local lp_path_format
-    _lp_path_format "$path_format" "$last_format" "$vcs_format" "$short_format" "/" "$separator_format"
+    _lp_path_format "$LP_COLOR_PATH" "$LP_COLOR_PATH_LAST_DIR" "$LP_COLOR_PATH_VCS_ROOT" "$LP_COLOR_PATH_SHORTENED" "/" "$LP_COLOR_PATH_SEPARATOR"
 
     LP_PWD="${lp_path_format}${NO_COL}"
 }

--- a/liquidprompt
+++ b/liquidprompt
@@ -42,7 +42,6 @@ if test -n "${BASH_VERSION-}"; then
     _LP_TIME_SYMBOL="\t"
     _LP_MARK_SYMBOL='\$'
     _LP_PWD_SYMBOL="\\w"
-    _LP_DIR_SYMBOL="\\W"
 
     _LP_FIRST_INDEX=0
     _LP_PERCENT='%'    # must be escaped on zsh
@@ -70,7 +69,6 @@ elif test -n "${ZSH_VERSION-}" ; then
     _LP_TIME_SYMBOL="%*"
     _LP_MARK_SYMBOL='%(!.#.%%)'
     _LP_PWD_SYMBOL="%~"
-    _LP_DIR_SYMBOL="%1~"
 
     _LP_FIRST_INDEX=1
     _LP_PERCENT='%%'
@@ -519,31 +517,6 @@ lp_activate() {
     # Where are we? #
     #################
 
-
-    if (( LP_ENABLE_SHORTEN_PATH )); then
-        if (( LP_PATH_KEEP == -1 )); then
-            lp_path=$_LP_DIR_SYMBOL
-            __lp_path() { : ; }
-        else
-            __lp_path() {
-                local lp_shorten_path
-                __lp_shorten_path
-                lp_path=$lp_shorten_path
-            }
-        fi
-    else
-        # Will never change
-        lp_path=$LP_PATH_DEFAULT
-
-        if (( _LP_SHELL_bash )) && [[ -n ${PROMPT_DIRTRIM-} ]]; then
-            __lp_path() {
-                __lp_set_dirtrim
-            }
-        else
-            __lp_path() { : ; }
-        fi
-    fi
-
     _LP_RUNTIME_LAST_SECONDS=$SECONDS
 
     if (( LP_ENABLE_RUNTIME || LP_ENABLE_RUNTIME_BELL)); then
@@ -641,11 +614,11 @@ __lp_hostname_hash() {
 }
 
 # Return $PWD with $HOME at the start replaced by "~".
-__lp_pwd_tilde() {
+__lp_pwd_tilde() {  # [path]
     # Needs to be in a variable, as different versions of Bash treat '~' in a
     # substitution differently
-    local tilde="~"
-    lp_pwd_tilde="${PWD/#$HOME/$tilde}"
+    local _path=${1:-$PWD} tilde="~"
+    lp_pwd_tilde="${_path/#$HOME/$tilde}"
 }
 
 # insert a space on the right
@@ -767,82 +740,101 @@ __lp_theme_zsh_complete() {
 # Working Directory Path #
 ##########################
 
-# Shorten the path of the current working directory
-__lp_shorten_path() {
-    local ret= lp_pwd_tilde p
-    __lp_pwd_tilde
-    p="$lp_pwd_tilde"
-
-    local mask="${LP_MARK_SHORTEN_PATH}"
-    local -i max_len=$(( ${COLUMNS:-80} * LP_PATH_LENGTH / 100 ))
-
-    if (( ${#p} <= max_len )); then
-        ret="${p}"
-    elif (( LP_PATH_KEEP == 0 )); then
-        # len is over max len, show as much of the tail as is allowed
-        ret="${p##*/}" # show at least complete current directory
-        p="${p:0:${#p} - ${#ret}}"
-        ret="${mask}${p:${#p} - (${max_len} - ${#ret} - ${#mask})}${ret}"
-    else
-        # len is over max len, show at least LP_PATH_KEEP leading dirs and
-        # current directory
-        local tmp="${p//\//}"
-        local -i delims=$(( ${#p} - ${#tmp} ))
-
-        for (( dir=0; dir < LP_PATH_KEEP; dir++ )); do
-            (( dir == delims )) && break
-
-            local left="${p#*/}"
-            local name="${p:0:${#p} - ${#left}}"
-            p="${left}"
-            ret+="${name%/}/"
-        done
-
-        if (( delims <= LP_PATH_KEEP )); then
-            # no dirs between LP_PATH_KEEP leading dirs and current dir
-            ret+="${p##*/}"
-        else
-            local base="${p##*/}"
-
-            p="${p:0:${#p} - ${#base}}"
-
-            [[ ${ret} != "/" ]] && ret="${ret%/}" # strip trailing slash
-
-            local -i len_left=$(( max_len - ${#ret} - ${#base} - ${#mask} ))
-
-            ret+="${mask}${p:${#p} - ${len_left}}${base}"
+__lp_get_unique_directory() {
+    lp_unique_directory=""
+    local directory=${1##*/} root=${1%/*}
+    local -a matching
+    local -i i
+    for (( i=0; i < $(( ${#directory} - 1 )); i++ )); do
+        lp_unique_directory+="${directory:$i:1}"
+        matching=("${root}/${lp_unique_directory}"*/)
+        if [[ ${#matching[@]} -eq 1 ]]; then
+            return 0
         fi
-    fi
-    # Escape special chars
-    __lp_escape "$ret"
-    lp_shorten_path="$ret"
+    done
+
+    return 1
 }
 
-# Calculate PROMPT_DIRTRIM; the number of directories to keep at the end
-# of the displayed path (if "\w" is present in the PS1 var).
-__lp_set_dirtrim() {
-    local lp_pwd_tilde p
+_lp_path_format() {
+    local path_format=${1-$LP_COLOR_PATH}
+    local last_directory_format=${2:-$path_format}
+    local vcs_root_format=${3:-$last_directory_format}
+    local shortened_directory_format=${4:-$path_format}
+    local separator=${5-"/"}
+    local separator_format=${6-}
+
+    lp_path=
+    lp_path_format=
+
+    local lp_pwd_tilde
     __lp_pwd_tilde
-    p="$lp_pwd_tilde"
+    local display_path=$lp_pwd_tilde
 
-    local -i max_len="${COLUMNS:-80}*$LP_PATH_LENGTH/100"
-    local -i dt=0
+    local -i path_length=${#display_path}
 
-    if (( ${#p} > max_len )); then
-        local q="/${p##*/}"
-        local show="$q"
-        # +3 because of the ellipsis: "..."
-        while (( ${#show}+3 < max_len )); do
-            (( dt++ ))
-            p="${p%$q}"
-            q="/${p##*/}"
-            show="$q$show"
-        done
-        (( dt == 0 )) && dt=1
+    if [[ $path_length > 1 ]]; then
+        if [[ $separator != "/" && ${display_path:0:1} == "/" ]]; then
+            # The root directory ('/') becomes a directory name instead of a leading separator
+            # Add one to account for the first / needing to be both replaced and shown
+            path_length+=1
+        fi
+        if [[ ${#separator} > 1 ]]; then
+            # Add length to account for multichar separators
+            local slash_count="${display_path//[!"/"]}"
+            path_length+=$(( ${#slash_count} * ( ${#separator} - 1 ) ))
+        fi
+    else
+        # only root or home to show
+        lp_path=$display_path
+        lp_path_format="${last_directory_format}${display_path}"
+        return
     fi
-    PROMPT_DIRTRIM=$dt
-    # For debugging
-    # echo PROMPT_DIRTRIM=$PROMPT_DIRTRIM >&2
+
+    local lp_vcs_root lp_vcs_type
+    local vcs_root_directory=
+    if _lp_find_vcs; then
+        __lp_pwd_tilde "$lp_vcs_root"
+        vcs_root_directory=$lp_pwd_tilde
+    fi
+
+    local path_to_proccess="${display_path}/" current_path="" current_directory="" lp_unique_directory
+
+    local -i max_len=$(( ${COLUMNS:-80} * LP_PATH_LENGTH / 100 ))
+    local shortened_path_length=$path_length
+
+    while [[ -n $path_to_proccess ]]; do
+
+        if [[ ${path_to_proccess:0:1} == "/" ]]; then
+            # Start of root
+            current_directory="/"
+        else
+            current_directory=${path_to_proccess%%/*}
+            if [[ -n $current_path && $current_path != "/" ]]; then
+                current_path+="/"
+            fi
+        fi
+
+        current_path+=${current_directory}
+        path_to_proccess=${path_to_proccess#*/}
+
+        if [[ $current_path == $vcs_root_directory ]]; then
+            # No shortening
+            lp_path_format+="${vcs_root_format}${current_directory}"
+        elif [[ -z $path_to_proccess ]]; then
+            # Last directory
+            lp_path_format+="${last_directory_format}${current_directory}"
+        elif (( shortened_path_length > max_len )) && __lp_get_unique_directory "$current_path"; then
+            lp_path_format+="${shortened_directory_format}${lp_unique_directory}"
+            shortened_path_length=$(( shortened_path_length - ${#current_directory} + ${#lp_unique_directory} ))
+        else
+            lp_path_format+="${path_format}${current_directory}"
+        fi
+
+        if [[ -n $path_to_proccess && ( $current_path != "/" || $separator != "/" ) ]]; then
+            lp_path_format+="${separator_format}${separator}"
+        fi
+    done
 }
 
 ###############
@@ -2461,6 +2453,23 @@ _lp_default_theme_directory() {
     fi
 
     LP_PWD="${LP_COLOR_PATH}${lp_path}${NO_COL}"
+
+    local lp_terminal_format
+    lp_terminal_format 250 240 0 0 7 0
+    local path_format=$lp_terminal_format
+    lp_terminal_format 245 240 0 0 7 0
+    local short_format=$lp_terminal_format
+    lp_terminal_format 245 240 0 0 7 0
+    local separator_format=$lp_terminal_format
+    lp_terminal_format 147 240 0 0 4 0
+    local vcs_format=$lp_terminal_format
+    lp_terminal_format 255 240 1 0 7 0
+    local last_format=$lp_terminal_format
+
+    local lp_path_format
+    _lp_path_format "$path_format" "$last_format" "$vcs_format" "$short_format" "/" "$separator_format"
+
+    LP_PWD="${lp_path_format}${NO_COL}"
 }
 
 _lp_default_theme_prompt_data() {
@@ -2605,8 +2614,6 @@ __lp_set_prompt() {
     if [[ "${LP_OLD_PWD-}" != "LP:$PWD" ]]; then
         # Update directory icon for MacOS X
         "$_LP_TERM_UPDATE_DIR"
-
-        __lp_path
 
         "$_LP_THEME_DIRECTORY_FUNCTION"
 

--- a/liquidprompt
+++ b/liquidprompt
@@ -860,7 +860,7 @@ _lp_path_format() {
         fi
         if [[ ${#separator} > 1 ]]; then
             # Add length to account for multichar separators
-            local slash_count="${display_path//[!"/"]}"
+            local slash_count="${display_path//[!\/]}"
             path_length+=$(( ${#slash_count} * ( ${#separator} - 1 ) ))
         fi
     fi

--- a/liquidprompt
+++ b/liquidprompt
@@ -798,8 +798,10 @@ __lp_end_path_left_shortening() {
             # This indescriminate adding of a separator can sometimes mean the path
             # is slightly longer than it should be, but it is more clear.
             lp_path_format+="${separator_format}${separator}"
+            lp_path+="${LP_MARK_SHORTEN_PATH}/"
         else
-            lp_path_format+=$unshortened_path_shorten_string
+            lp_path+=$unshortened_path_shorten_string
+            lp_path_format+=$unshortened_path_format_shorten_string
             shortened_path_length=$unshortened_path_length
         fi
         is_shortening=0
@@ -867,7 +869,7 @@ _lp_path_format() {
 
     local -i max_len=$(( ${COLUMNS:-80} * LP_PATH_LENGTH / 100 )) directory_count=0 needed_length
     local -i shortened_path_length=$path_length is_shortening=0 unshortened_path_length
-    local unshortened_path_shorten_string
+    local unshortened_path_shorten_string unshortened_path_format_shorten_string shortened_path
 
     while [[ -n $path_to_proccess ]]; do
 
@@ -888,10 +890,12 @@ _lp_path_format() {
         if [[ $current_path == $vcs_root_directory ]]; then
             __lp_end_path_left_shortening
             # No shortening
+            lp_path+=$current_directory
             lp_path_format+="${vcs_root_format}${current_directory}"
         elif [[ -z $path_to_proccess ]]; then
             __lp_end_path_left_shortening
             # Last directory
+            lp_path+=$current_directory
             lp_path_format+="${last_directory_format}${current_directory}"
         elif (( LP_ENABLE_SHORTEN_PATH && directory_count > LP_PATH_KEEP \
             && ( shortened_path_length > max_len || ( shortened_path_length >= max_len && is_shortening ) ) )); then
@@ -899,6 +903,7 @@ _lp_path_format() {
             if [[ $LP_PATH_METHOD == "truncate_chars_to_unique_dir" ]] && \
                 __lp_get_unique_directory "$current_path"; then
 
+                lp_path+=$lp_unique_directory
                 lp_path_format+="${shortened_directory_format}${lp_unique_directory}"
                 shortened_path_length=$(( shortened_path_length - ${#current_directory} + ${#lp_unique_directory} ))
             elif [[ $LP_PATH_METHOD == "truncate_chars_from_path_left" ]]; then
@@ -908,12 +913,14 @@ _lp_path_format() {
 
                 if (( ! is_shortening )); then
                     unshortened_path_shorten_string=
+                    unshortened_path_format_shorten_string=
                     unshortened_path_length=$shortened_path_length
                     shortened_path_length+=${#LP_MARK_SHORTEN_PATH}
                 fi
                 needed_length=$(( shortened_path_length - max_len ))
 
-                unshortened_path_shorten_string+="${path_format}${current_directory}${separator_format}${separator}"
+                unshortened_path_shorten_string+="${current_directory}/"
+                unshortened_path_format_shorten_string+="${path_format}${current_directory}${separator_format}${separator}"
 
                 if (( needed_length >= ${#current_directory} )); then
                     # One directory was not enough, need to shorten more.
@@ -925,33 +932,42 @@ _lp_path_format() {
                     # If we got to here, it wasn't a forced ending, which means it is.
                     shortened_path_length=$(( shortened_path_length - needed_length ))
 
-                    lp_path_format+="${shortened_directory_format}${LP_MARK_SHORTEN_PATH}"
-                    lp_path_format+=${current_directory:$needed_length}
+                    shortened_path="${LP_MARK_SHORTEN_PATH}${current_directory:$needed_length}"
+                    lp_path+=$shortened_path
+                    lp_path_format+="${shortened_directory_format}${shortened_path}"
 
                     is_shortening=0
                 fi
             elif [[ $LP_PATH_METHOD == "truncate_chars_from_dir_right" ]] && \
                 (( ${#LP_MARK_SHORTEN_PATH} + LP_PATH_CHARACTER_KEEP < ${#current_directory} )); then
 
-                lp_path_format+="${shortened_directory_format}${current_directory:0:$LP_PATH_CHARACTER_KEEP}${LP_MARK_SHORTEN_PATH}"
+                shortened_path="${current_directory:0:$LP_PATH_CHARACTER_KEEP}${LP_MARK_SHORTEN_PATH}"
+                lp_path+=$shortened_path
+                lp_path_format+="${shortened_directory_format}${shortened_path}"
                 shortened_path_length=$(( shortened_path_length - ${#current_directory} + ${#LP_MARK_SHORTEN_PATH} + LP_PATH_CHARACTER_KEEP ))
             elif [[ $LP_PATH_METHOD == "truncate_chars_from_dir_middle" ]] && \
                 (( ${#LP_MARK_SHORTEN_PATH} + LP_PATH_CHARACTER_KEEP * 2 < ${#current_directory} )); then
 
-                lp_path_format+="${shortened_directory_format}${current_directory:0:$LP_PATH_CHARACTER_KEEP}"
-                lp_path_format+="${LP_MARK_SHORTEN_PATH}${current_directory: -$LP_PATH_CHARACTER_KEEP}"
+                shortened_path="${current_directory:0:$LP_PATH_CHARACTER_KEEP}${LP_MARK_SHORTEN_PATH}${current_directory: -$LP_PATH_CHARACTER_KEEP}"
+                lp_path+=$shortened_path
+                lp_path_format+="${shortened_directory_format}${shortened_path}"
                 shortened_path_length=$(( shortened_path_length - ${#current_directory} + ${#LP_MARK_SHORTEN_PATH} + LP_PATH_CHARACTER_KEEP * 2 ))
             else
                 # Need to shorten, but no method matched, or the matched method
                 # did not make the string any shorter.
+                lp_path+=$current_directory
                 lp_path_format+="${path_format}${current_directory}"
             fi
         else
             __lp_end_path_left_shortening
+            lp_path+=$current_directory
             lp_path_format+="${path_format}${current_directory}"
         fi
 
         if [[ -n $path_to_proccess && ( $current_path != "/" || $separator != "/" ) ]] && (( ! is_shortening )); then
+            if [[ $current_path != "/" ]]; then
+                lp_path+="/"
+            fi
             lp_path_format+="${separator_format}${separator}"
         fi
     done
@@ -2572,7 +2588,7 @@ _lp_default_theme_directory() {
         fi
     fi
 
-    local lp_path_format
+    local lp_path lp_path_format
     _lp_path_format "$LP_COLOR_PATH" "$LP_COLOR_PATH_LAST_DIR" "$LP_COLOR_PATH_VCS_ROOT" "$LP_COLOR_PATH_SHORTENED" "/" "$LP_COLOR_PATH_SEPARATOR"
 
     LP_PWD="${lp_path_format}${NO_COL}"

--- a/liquidprompt
+++ b/liquidprompt
@@ -744,14 +744,13 @@ __lp_theme_zsh_complete() {
 ##########################
 
 __lp_get_unique_directory() {
-    lp_unique_directory=""
     local directory=${1##*/} root=${1%/*}
     local -a matching
     local -i i
-    for (( i=0; i < $(( ${#directory} - 1 )); i++ )); do
-        lp_unique_directory+="${directory:$i:1}"
+    for (( i=1; i < ${#directory}; i++ )); do
+        lp_unique_directory=${directory:0:$i}
         matching=("${root}/${lp_unique_directory}"*/)
-        if [[ ${#matching[@]} -eq 1 ]]; then
+        if (( ${#matching[@]} == 1 )); then
             return 0
         fi
     done

--- a/liquidprompt
+++ b/liquidprompt
@@ -758,6 +758,22 @@ __lp_get_unique_directory() {
     return 1
 }
 
+__lp_end_path_left_shortening() {
+    if (( is_shortening )); then
+        shortened_path_length+=${#separator}
+        if (( shortened_path_length < unshortened_path_length )); then
+            lp_path_format+="${shortened_directory_format}${LP_MARK_SHORTEN_PATH}"
+            # This indescriminate adding of a separator can sometimes mean the path
+            # is slightly longer than it should be, but it is more clear.
+            lp_path_format+="${separator_format}${separator}"
+        else
+            lp_path_format+=$unshortened_path_shorten_string
+            shortened_path_length=$unshortened_path_length
+        fi
+        is_shortening=0
+    fi
+}
+
 # methods:
 #   truncate_chars_from_path_left
 #   truncate_chars_from_dir_middle
@@ -810,7 +826,8 @@ _lp_path_format() {
     local path_to_proccess="${display_path}/" current_path="" current_directory="" lp_unique_directory
 
     local -i max_len=$(( ${COLUMNS:-80} * LP_PATH_LENGTH / 100 )) directory_count=0 needed_length
-    local shortened_path_length=$path_length
+    local -i shortened_path_length=$path_length is_shortening=0 unshortened_path_length
+    local unshortened_path_shorten_string
 
     while [[ -n $path_to_proccess ]]; do
 
@@ -829,29 +846,49 @@ _lp_path_format() {
         path_to_proccess=${path_to_proccess#*/}
 
         if [[ $current_path == $vcs_root_directory ]]; then
+            __lp_end_path_left_shortening
             # No shortening
             lp_path_format+="${vcs_root_format}${current_directory}"
         elif [[ -z $path_to_proccess ]]; then
+            __lp_end_path_left_shortening
             # Last directory
             lp_path_format+="${last_directory_format}${current_directory}"
-        elif (( shortened_path_length > max_len && directory_count > LP_PATH_KEEP )); then
-            needed_length=$(( shortened_path_length - max_len ))
+        elif (( LP_ENABLE_SHORTEN_PATH && directory_count > LP_PATH_KEEP \
+            && ( shortened_path_length > max_len || ( shortened_path_length >= max_len && is_shortening ) ) )); then
 
             if [[ $LP_PATH_METHOD == "truncate_chars_to_unique_dir" ]] && \
                 __lp_get_unique_directory "$current_path"; then
 
                 lp_path_format+="${shortened_directory_format}${lp_unique_directory}"
                 shortened_path_length=$(( shortened_path_length - ${#current_directory} + ${#lp_unique_directory} ))
-            elif [[ $LP_PATH_METHOD == "truncate_chars_from_path_left" ]] && \
-                (( ${#LP_MARK_SHORTEN_PATH} < ${#current_directory} )); then
+            elif [[ $LP_PATH_METHOD == "truncate_chars_from_path_left" ]]; then
+                # The only way to know if this consecutive directory shortening
+                # will actually shorten the path is to both do it and do not and
+                # compare at the end.
 
-                lp_path_format+="${shortened_directory_format}${LP_MARK_SHORTEN_PATH}"
+                if (( ! is_shortening )); then
+                    unshortened_path_shorten_string=
+                    unshortened_path_length=$shortened_path_length
+                    shortened_path_length+=${#LP_MARK_SHORTEN_PATH}
+                fi
+                needed_length=$(( shortened_path_length - max_len ))
+
+                unshortened_path_shorten_string+="${path_format}${current_directory}${separator_format}${separator}"
 
                 if (( needed_length >= ${#current_directory} )); then
-                    shortened_path_length=$(( shortened_path_length - ${#current_directory} ))
+                    # One directory was not enough, need to shorten more.
+                    # Shorten by current directory length plus separator.
+                    shortened_path_length=$(( shortened_path_length - ${#current_directory} - ${#separator} ))
+                    is_shortening=1
                 else
-                    lp_path_format+="${current_directory:$needed_length}"
+                    # Do not need to check if the shortened version is actually shorter.
+                    # If we got to here, it wasn't a forced ending, which means it is.
                     shortened_path_length=$(( shortened_path_length - needed_length ))
+
+                    lp_path_format+="${shortened_directory_format}${LP_MARK_SHORTEN_PATH}"
+                    lp_path_format+=${current_directory:$needed_length}
+
+                    is_shortening=0
                 fi
             elif [[ $LP_PATH_METHOD == "truncate_chars_from_dir_right" ]] && \
                 (( ${#LP_MARK_SHORTEN_PATH} + LP_PATH_CHARACTER_KEEP < ${#current_directory} )); then
@@ -870,10 +907,11 @@ _lp_path_format() {
                 lp_path_format+="${path_format}${current_directory}"
             fi
         else
+            __lp_end_path_left_shortening
             lp_path_format+="${path_format}${current_directory}"
         fi
 
-        if [[ -n $path_to_proccess && ( $current_path != "/" || $separator != "/" ) ]]; then
+        if [[ -n $path_to_proccess && ( $current_path != "/" || $separator != "/" ) ]] && (( ! is_shortening )); then
             lp_path_format+="${separator_format}${separator}"
         fi
     done

--- a/liquidprompt
+++ b/liquidprompt
@@ -41,7 +41,6 @@ if test -n "${BASH_VERSION-}"; then
     _LP_FQDN_SYMBOL="\H"
     _LP_TIME_SYMBOL="\t"
     _LP_MARK_SYMBOL='\$'
-    _LP_PWD_SYMBOL="\\w"
 
     _LP_FIRST_INDEX=0
     _LP_PERCENT='%'    # must be escaped on zsh
@@ -68,7 +67,6 @@ elif test -n "${ZSH_VERSION-}" ; then
     _LP_FQDN_SYMBOL="%M"
     _LP_TIME_SYMBOL="%*"
     _LP_MARK_SYMBOL='%(!.#.%%)'
-    _LP_PWD_SYMBOL="%~"
 
     _LP_FIRST_INDEX=1
     _LP_PERCENT='%%'
@@ -183,7 +181,6 @@ __lp_source_config() {
     LP_PATH_CHARACTER_KEEP=${LP_PATH_CHARACTER_KEEP:-3}
     LP_PATH_METHOD=${LP_PATH_METHOD:-truncate_chars_from_path_left}
     LP_PATH_VCS_ROOT=${LP_PATH_VCS_ROOT:-1}
-    LP_PATH_DEFAULT="${LP_PATH_DEFAULT:-$_LP_PWD_SYMBOL}"
     LP_HOSTNAME_ALWAYS=${LP_HOSTNAME_ALWAYS:-0}
     LP_USER_ALWAYS=${LP_USER_ALWAYS:-1}
     LP_PERCENTS_ALWAYS=${LP_PERCENTS_ALWAYS:-1}
@@ -322,6 +319,8 @@ __lp_source_config() {
         fi
     done
 
+    # Deprecations and compatability shims
+
     if [[ -n "${LP_DISABLED_VCS_PATH-}" ]]; then
         echo "liquidprompt: LP_DISABLED_VCS_PATH is deprecated. Update your config to use LP_DISABLED_VCS_PATHS array." >&2
 
@@ -349,6 +348,32 @@ __lp_source_config() {
         )
         unset LP_COLORMAP_0 LP_COLORMAP_1 LP_COLORMAP_2 LP_COLORMAP_3 LP_COLORMAP_4 \
               LP_COLORMAP_5 LP_COLORMAP_6 LP_COLORMAP_7 LP_COLORMAP_8 LP_COLORMAP_9
+    fi
+
+    if [[ -n ${LP_PATH_DEFAULT-} ]]; then
+        echo "liquidprompt: LP_PATH_DEFAULT is deprecated. Update your config to set LP_PATH_METHOD." >&2
+        if (( ! LP_ENABLE_SHORTEN_PATH )); then
+            # There is just no elegant way to handle this. Fallback to the old way with basic formatting support.
+            _lp_path_format() {
+                lp_path=$LP_PATH_DEFAULT
+                lp_path_format="${LP_COLOR_PATH}${lp_path}${NO_COL}"
+            }
+        fi
+    fi
+
+    if [[ -n ${PROMPT_DIRTRIM-} ]] && (( ! LP_ENABLE_SHORTEN_PATH )); then
+        echo "liquidprompt: PROMPT_DIRTRIM support is deprecated. Update your config to set
+            LP_PATH_METHOD='truncate_chars_from_path_left' instead." >&2
+        # This does mostly the same thing, but with our formatting.
+        LP_ENABLE_SHORTEN_PATH=1
+        LP_PATH_METHOD="truncate_chars_from_path_left"
+        LP_PATH_KEEP=1
+    fi
+
+    if [[ $LP_PATH_KEEP == "-1" ]]; then
+        echo "liquidprompt: LP_PATH_KEEP set to '-1' is deprecated. Update your config to set
+              LP_PATH_METHOD='truncate_to_last_dir' instead." >&2
+        LP_PATH_METHOD="truncate_to_last_dir"
     fi
 }
 

--- a/tests/test_utils.sh
+++ b/tests/test_utils.sh
@@ -103,6 +103,7 @@ function test_path_format() {
 
   typeset COLUMNS=100
   LP_PATH_LENGTH=100
+  LP_PATH_VCS_ROOT=1
 
   typeset lp_path_format
 

--- a/tests/test_utils.sh
+++ b/tests/test_utils.sh
@@ -103,6 +103,7 @@ function test_path_format() {
 
   typeset COLUMNS=100
   LP_PATH_LENGTH=100
+  LP_PATH_KEEP=0
   LP_PATH_VCS_ROOT=1
 
   typeset lp_path_format
@@ -142,10 +143,19 @@ function test_path_format() {
   _lp_path_format '{n}' '{l}' '{v}' '{s}'
   assertEquals "medium directory formatting" "{n}/{s}t/{n}_lp/{n}a/{l}very" "$lp_path_format"
 
+  LP_PATH_KEEP=2
+  _lp_path_format '{n}' '{l}' '{v}' '{s}'
+  assertEquals "medium directory formatting" "{n}/{n}tmp/{s}_/{n}a/{l}very" "$lp_path_format"
+
+  LP_PATH_KEEP=3
+  _lp_path_format '{n}' '{l}' '{v}' '{s}'
+  assertEquals "medium directory formatting" "{n}/{n}tmp/{n}_lp/{n}a/{l}very" "$lp_path_format"
+
   _lp_find_vcs() {
     lp_vcs_root="/tmp/_lp/a/very"
   }
 
+  LP_PATH_KEEP=0
   PWD="/tmp/_lp/a/very/long/pathname"
   _lp_path_format '{n}' '{l}' '{v}' '{s}'
   assertEquals "full directory formatting" "{n}/{s}t/{s}_/{n}a/{v}very/{s}l/{l}pathname" "$lp_path_format"

--- a/tests/test_utils.sh
+++ b/tests/test_utils.sh
@@ -211,6 +211,170 @@ function test_path_format_from_path_left() {
   assertEquals "no shortening" "/tmp/a/b/c/last" "$lp_path_format"
 }
 
+function test_path_format_from_dir_right {
+  typeset HOME="/home/user"
+  typeset PWD="/"
+
+  _lp_find_vcs() {
+    return 1
+  }
+
+  LP_ENABLE_SHORTEN_PATH=1
+  typeset COLUMNS=100
+  LP_PATH_LENGTH=100
+  LP_PATH_KEEP=0
+  LP_PATH_VCS_ROOT=1
+  LP_PATH_METHOD=truncate_chars_from_dir_right
+  LP_MARK_SHORTEN_PATH="..."
+  LP_PATH_CHARACTER_KEEP=1
+
+  typeset lp_path_format
+
+  _lp_path_format '{format}'
+  assertEquals "root directory formatting" '{format}/' "$lp_path_format"
+
+  _lp_path_format '{format}' '' '' '' '['
+  assertEquals "root directory formatting ignore separator" '{format}/' "$lp_path_format"
+
+  PWD="/tmp"
+  _lp_path_format ''
+  assertEquals "root directory no formatting" '/tmp' "$lp_path_format"
+
+  _lp_path_format '' '' '' '' '^'
+  assertEquals "root directory no formatting custom separator" '/^tmp' "$lp_path_format"
+
+  PWD=$HOME
+  _lp_path_format '{format}'
+  assertEquals "home directory formatting" '{format}~' "$lp_path_format"
+
+  PWD="/tmp/_lp/a"
+  _lp_path_format ''
+  assertEquals "short directory formatting" "$PWD" "$lp_path_format"
+
+  LP_PATH_LENGTH=1
+
+  PWD="/tmp/_lp/a/very"
+  _lp_path_format ''
+  assertEquals "short directory formatting" "$PWD" "$lp_path_format"
+
+  PWD="/avery/muchlong/pathname"
+  _lp_path_format ''
+  assertEquals "short directory formatting" "/a.../m.../pathname" "$lp_path_format"
+
+  LP_PATH_LENGTH=$(( ${#PWD} - 1 ))
+  _lp_path_format ''
+  assertEquals "medium directory formatting" "/a.../muchlong/pathname" "$lp_path_format"
+
+  LP_PATH_KEEP=2
+  _lp_path_format ''
+  assertEquals "medium directory formatting" "/avery/m.../pathname" "$lp_path_format"
+
+  _lp_find_vcs() {
+    lp_vcs_root="/tmp/_lp/a/very"
+  }
+
+  LP_PATH_KEEP=0
+  LP_MARK_SHORTEN_PATH="."
+  PWD="/tmp/_lp/a/very/long/pathname"
+  _lp_path_format '{n}' '{l}' '{v}' '{s}'
+  assertEquals "full directory formatting" "{n}/{s}t./{s}_./{n}a/{v}very/{s}l./{l}pathname" "$lp_path_format"
+
+  LP_PATH_KEEP=2
+  PWD="/tmp/averylong/superduperlong/obviouslytoolong/dir"
+
+  LP_PATH_LENGTH=31
+  _lp_path_format '{n}' '{l}' '{v}' '{s}'
+  assertEquals "full directory formatting length $LP_PATH_LENGTH" "{n}/{n}tmp/{s}a./{s}s./{n}obviouslytoolong/{l}dir" "$lp_path_format"
+
+  LP_PATH_LENGTH=30
+  _lp_path_format '{n}' '{l}' '{v}' '{s}'
+  assertEquals "full directory formatting length $LP_PATH_LENGTH" "{n}/{n}tmp/{s}a./{s}s./{s}o./{l}dir" "$lp_path_format"
+}
+
+function test_path_format_from_dir_middle {
+  typeset HOME="/home/user"
+  typeset PWD="/"
+
+  _lp_find_vcs() {
+    return 1
+  }
+
+  LP_ENABLE_SHORTEN_PATH=1
+  typeset COLUMNS=100
+  LP_PATH_LENGTH=100
+  LP_PATH_KEEP=0
+  LP_PATH_VCS_ROOT=1
+  LP_PATH_METHOD=truncate_chars_from_dir_middle
+  LP_MARK_SHORTEN_PATH="..."
+  LP_PATH_CHARACTER_KEEP=1
+
+  typeset lp_path_format
+
+  _lp_path_format '{format}'
+  assertEquals "root directory formatting" '{format}/' "$lp_path_format"
+
+  _lp_path_format '{format}' '' '' '' '['
+  assertEquals "root directory formatting ignore separator" '{format}/' "$lp_path_format"
+
+  PWD="/tmp"
+  _lp_path_format ''
+  assertEquals "root directory no formatting" '/tmp' "$lp_path_format"
+
+  _lp_path_format '' '' '' '' '^'
+  assertEquals "root directory no formatting custom separator" '/^tmp' "$lp_path_format"
+
+  PWD=$HOME
+  _lp_path_format '{format}'
+  assertEquals "home directory formatting" '{format}~' "$lp_path_format"
+
+  PWD="/tmp/_lp/a"
+  _lp_path_format ''
+  assertEquals "short directory formatting" "$PWD" "$lp_path_format"
+
+  LP_PATH_LENGTH=1
+
+  PWD="/tmp/_lp/a/very"
+  _lp_path_format ''
+  assertEquals "short directory formatting" "$PWD" "$lp_path_format"
+
+  PWD="/avery/muchlong/pathname"
+  _lp_path_format ''
+  assertEquals "short directory formatting" "/avery/m...g/pathname" "$lp_path_format"
+
+  LP_MARK_SHORTEN_PATH="."
+  PWD="/avery/muchlong/pathname"
+  _lp_path_format ''
+  assertEquals "short directory formatting" "/a.y/m.g/pathname" "$lp_path_format"
+
+  LP_PATH_LENGTH=$(( ${#PWD} - 1 ))
+  _lp_path_format ''
+  assertEquals "medium directory formatting" "/a.y/muchlong/pathname" "$lp_path_format"
+
+  LP_PATH_KEEP=2
+  _lp_path_format ''
+  assertEquals "medium directory formatting" "/avery/m.g/pathname" "$lp_path_format"
+
+  _lp_find_vcs() {
+    lp_vcs_root="/tmp/_lp/a/very"
+  }
+
+  LP_PATH_KEEP=0
+  PWD="/tmp/_lp/a/very/long/pathname"
+  _lp_path_format '{n}' '{l}' '{v}' '{s}'
+  assertEquals "full directory formatting" "{n}/{n}tmp/{n}_lp/{n}a/{v}very/{s}l.g/{l}pathname" "$lp_path_format"
+
+  LP_PATH_KEEP=2
+  PWD="/tmp/averylong/superduperlong/obviouslytoolong/dir"
+
+  LP_PATH_LENGTH=33
+  _lp_path_format '{n}' '{l}' '{v}' '{s}'
+  assertEquals "full directory formatting length $LP_PATH_LENGTH" "{n}/{n}tmp/{s}a.g/{s}s.g/{n}obviouslytoolong/{l}dir" "$lp_path_format"
+
+  LP_PATH_LENGTH=32
+  _lp_path_format '{n}' '{l}' '{v}' '{s}'
+  assertEquals "full directory formatting length $LP_PATH_LENGTH" "{n}/{n}tmp/{s}a.g/{s}s.g/{s}o.g/{l}dir" "$lp_path_format"
+}
+
 function test_path_format_unique() {
   pathSetUp
 

--- a/tests/test_utils.sh
+++ b/tests/test_utils.sh
@@ -452,6 +452,68 @@ function test_path_format_unique() {
   pathTearDown
 }
 
+function test_path_format_last_dir() {
+  typeset HOME="/home/user"
+  typeset PWD="/"
+
+  _lp_find_vcs() {
+    return 1
+  }
+
+  LP_ENABLE_SHORTEN_PATH=1
+  LP_PATH_VCS_ROOT=1
+  LP_PATH_METHOD=truncate_to_last_dir
+
+  typeset lp_path_format
+
+  _lp_path_format '{format}'
+  assertEquals "root directory formatting" '{format}/' "$lp_path_format"
+
+  _lp_path_format '{format}' '' '' '' '['
+  assertEquals "root directory formatting ignore separator" '{format}/' "$lp_path_format"
+
+  PWD="/tmp"
+  _lp_path_format ''
+  assertEquals "root directory no formatting" 'tmp' "$lp_path_format"
+
+  _lp_path_format '' '' '' '' '^'
+  assertEquals "root directory no formatting custom separator" 'tmp' "$lp_path_format"
+
+  PWD=$HOME
+  _lp_path_format '{format}'
+  assertEquals "home directory formatting" '{format}~' "$lp_path_format"
+
+  PWD="/tmp/_lp/a"
+  _lp_path_format ''
+  assertEquals "short directory formatting" "a" "$lp_path_format"
+
+  PWD="/tmp/_lp/a/very"
+  _lp_path_format ''
+  assertEquals "short directory formatting" "very" "$lp_path_format"
+
+  _lp_path_format '{n}' '{l}' '{v}' '{s}'
+  assertEquals "shortened directory formatting" "{l}very" "$lp_path_format"
+
+  _lp_path_format '{n}' '{l}' '{v}' '{s}'
+  assertEquals "medium directory formatting" "{l}very" "$lp_path_format"
+
+  _lp_find_vcs() {
+    lp_vcs_root="$PWD"
+  }
+
+  PWD="/tmp/_lp/a/very"
+  _lp_path_format '{n}' '{l}' '{v}' '{s}'
+  assertEquals "full directory vcs formatting" "{v}very" "$lp_path_format"
+
+  LP_PATH_VCS_ROOT=0
+  _lp_path_format '{n}' '{l}' '{v}' '{s}'
+  assertEquals "full directory formatting" "{l}very" "$lp_path_format"
+
+  PWD="/tmp/_lp/a/very/long/pathname"
+  _lp_path_format '{n}' '{l}' '{v}' '{s}' '^' '{^}'
+  assertEquals "full directory formatting with separator" "{l}pathname" "$lp_path_format"
+}
+
 function test_is_function {
   function my_function { :; }
 

--- a/tests/test_utils.sh
+++ b/tests/test_utils.sh
@@ -177,6 +177,10 @@ function test_path_format_from_path_left() {
   assertEquals "full directory with separator" ".../very/.../pathname" "$lp_path"
   assertEquals "full directory formatting with separator" "{s}...{^}^{v}very{^}^{s}...{^}^{l}pathname" "$lp_path_format"
 
+  _lp_path_format '{n}' '{l}' '{v}' '{s}' '///'
+  assertEquals "full directory with multichar separator" ".../very/.../pathname" "$lp_path"
+  assertEquals "full directory formatting with multichar separator" "{s}...///{v}very///{s}...///{l}pathname" "$lp_path_format"
+
   LP_PATH_KEEP=2
   PWD="/tmp/averylong/superduperlong/obviouslytoolong/dir"
 
@@ -300,6 +304,10 @@ function test_path_format_from_dir_right {
   assertEquals "full directory" "/t./_./a/very/l./pathname" "$lp_path"
   assertEquals "full directory formatting" "{n}/{s}t./{s}_./{n}a/{v}very/{s}l./{l}pathname" "$lp_path_format"
 
+  _lp_path_format '{n}' '{l}' '{v}' '{s}' '///'
+  assertEquals "full directory with multichar separator" "/t./_./a/very/l./pathname" "$lp_path"
+  assertEquals "full directory formatting with multichar separator" "{n}////{s}t.///{s}_.///{n}a///{v}very///{s}l.///{l}pathname" "$lp_path_format"
+
   LP_PATH_KEEP=2
   PWD="/tmp/averylong/superduperlong/obviouslytoolong/dir"
 
@@ -397,6 +405,10 @@ function test_path_format_from_dir_middle {
   _lp_path_format '{n}' '{l}' '{v}' '{s}'
   assertEquals "full directory" "/tmp/_lp/a/very/l.g/pathname" "$lp_path"
   assertEquals "full directory formatting" "{n}/{n}tmp/{n}_lp/{n}a/{v}very/{s}l.g/{l}pathname" "$lp_path_format"
+
+  _lp_path_format '{n}' '{l}' '{v}' '{s}' '///'
+  assertEquals "full directory with multichar separator" "/tmp/_lp/a/very/l.g/pathname" "$lp_path"
+  assertEquals "full directory formatting with multichar separator" "{n}////{n}tmp///{n}_lp///{n}a///{v}very///{s}l.g///{l}pathname" "$lp_path_format"
 
   LP_PATH_KEEP=2
   PWD="/tmp/averylong/superduperlong/obviouslytoolong/dir"
@@ -499,6 +511,10 @@ function test_path_format_unique() {
   assertEquals "full directory with separator" "/t/_/a/very/l/pathname" "$lp_path"
   assertEquals "full directory formatting with separator" "{n}/{^}^{s}t{^}^{s}_{^}^{n}a{^}^{v}very{^}^{s}l{^}^{l}pathname" "$lp_path_format"
 
+  _lp_path_format '{n}' '{l}' '{v}' '{s}' '///'
+  assertEquals "full directory with multichar separator" "/t/_/a/very/l/pathname" "$lp_path"
+  assertEquals "full directory formatting with multichar separator" "{n}////{s}t///{s}_///{n}a///{v}very///{s}l///{l}pathname" "$lp_path_format"
+
   pathTearDown
 }
 
@@ -570,6 +586,10 @@ function test_path_format_last_dir() {
   _lp_path_format '{n}' '{l}' '{v}' '{s}' '^' '{^}'
   assertEquals "full directory with separator" "pathname" "$lp_path"
   assertEquals "full directory formatting with separator" "{l}pathname" "$lp_path_format"
+
+  _lp_path_format '{n}' '{l}' '{v}' '{s}' '///'
+  assertEquals "full directory with multichar separator" "pathname" "$lp_path"
+  assertEquals "full directory formatting with multichar separator" "{l}pathname" "$lp_path_format"
 }
 
 function test_is_function {

--- a/tests/test_utils.sh
+++ b/tests/test_utils.sh
@@ -107,49 +107,60 @@ function test_path_format_from_path_left() {
   LP_PATH_METHOD=truncate_chars_from_path_left
   LP_MARK_SHORTEN_PATH="..."
 
-  typeset lp_path_format
+  typeset lp_path lp_path_format
 
   _lp_path_format '{format}'
+  assertEquals "root directory" '/' "$lp_path"
   assertEquals "root directory formatting" '{format}/' "$lp_path_format"
 
   _lp_path_format '{format}' '' '' '' '['
+  assertEquals "root directory ignore separator" '/' "$lp_path"
   assertEquals "root directory formatting ignore separator" '{format}/' "$lp_path_format"
 
   PWD="/tmp"
   _lp_path_format ''
-  assertEquals "root directory no formatting" '/tmp' "$lp_path_format"
+  assertEquals "tmp directory" '/tmp' "$lp_path"
+  assertEquals "tmp directory no formatting" '/tmp' "$lp_path_format"
 
   _lp_path_format '' '' '' '' '^'
-  assertEquals "root directory no formatting custom separator" '/^tmp' "$lp_path_format"
+  assertEquals "tmp directory no custom separator" '/tmp' "$lp_path"
+  assertEquals "tmp directory no formatting custom separator" '/^tmp' "$lp_path_format"
 
   PWD=$HOME
   _lp_path_format '{format}'
+  assertEquals "home directory" '~' "$lp_path"
   assertEquals "home directory formatting" '{format}~' "$lp_path_format"
 
   PWD="/tmp/_lp/a"
   _lp_path_format ''
+  assertEquals "short directory" "$PWD" "$lp_path"
   assertEquals "short directory formatting" "$PWD" "$lp_path_format"
 
   LP_PATH_LENGTH=1
 
   PWD="/tmp/_lp/a/very"
   _lp_path_format ''
+  assertEquals "short directory" ".../very" "$lp_path"
   assertEquals "short directory formatting" ".../very" "$lp_path_format"
 
   _lp_path_format '{n}' '{l}' '{v}' '{s}'
+  assertEquals "shortened directory" ".../very" "$lp_path"
   assertEquals "shortened directory formatting" "{s}.../{l}very" "$lp_path_format"
 
   LP_PATH_LENGTH=13
   _lp_path_format '{n}' '{l}' '{v}' '{s}'
+  assertEquals "medium directory" ".../_lp/a/very" "$lp_path"
   assertEquals "medium directory formatting" "{s}.../{n}_lp/{n}a/{l}very" "$lp_path_format"
 
   LP_PATH_KEEP=2
   _lp_path_format '{n}' '{l}' '{v}' '{s}'
+  assertEquals "medium directory" "/tmp/.../very" "$lp_path"
   assertEquals "medium directory formatting" "{n}/{n}tmp/{s}.../{l}very" "$lp_path_format"
 
   LP_PATH_KEEP=3
   # Don't shorten if it would make longer
   _lp_path_format '{n}' '{l}' '{v}' '{s}'
+  assertEquals "medium directory" "/tmp/_lp/a/very" "$lp_path"
   assertEquals "medium directory formatting" "{n}/{n}tmp/{n}_lp/{n}a/{l}very" "$lp_path_format"
 
   _lp_find_vcs() {
@@ -159,9 +170,11 @@ function test_path_format_from_path_left() {
   LP_PATH_KEEP=0
   PWD="/tmp/_lp/a/very/long/pathname"
   _lp_path_format '{n}' '{l}' '{v}' '{s}'
+  assertEquals "full directory" ".../very/.../pathname" "$lp_path"
   assertEquals "full directory formatting" "{s}.../{v}very/{s}.../{l}pathname" "$lp_path_format"
 
   _lp_path_format '{n}' '{l}' '{v}' '{s}' '^' '{^}'
+  assertEquals "full directory with separator" ".../very/.../pathname" "$lp_path"
   assertEquals "full directory formatting with separator" "{s}...{^}^{v}very{^}^{s}...{^}^{l}pathname" "$lp_path_format"
 
   LP_PATH_KEEP=2
@@ -228,33 +241,40 @@ function test_path_format_from_dir_right {
   LP_MARK_SHORTEN_PATH="..."
   LP_PATH_CHARACTER_KEEP=1
 
-  typeset lp_path_format
+  typeset lp_path lp_path_format
 
   _lp_path_format '{format}'
+  assertEquals "root directory" '/' "$lp_path"
   assertEquals "root directory formatting" '{format}/' "$lp_path_format"
 
   _lp_path_format '{format}' '' '' '' '['
+  assertEquals "root directory ignore separator" '/' "$lp_path"
   assertEquals "root directory formatting ignore separator" '{format}/' "$lp_path_format"
 
   PWD="/tmp"
   _lp_path_format ''
-  assertEquals "root directory no formatting" '/tmp' "$lp_path_format"
+  assertEquals "tmp directory" '/tmp' "$lp_path"
+  assertEquals "tmp directory no formatting" '/tmp' "$lp_path_format"
 
   _lp_path_format '' '' '' '' '^'
-  assertEquals "root directory no formatting custom separator" '/^tmp' "$lp_path_format"
+  assertEquals "tmp directory custom separator" '/tmp' "$lp_path"
+  assertEquals "tmp directory no formatting custom separator" '/^tmp' "$lp_path_format"
 
   PWD=$HOME
   _lp_path_format '{format}'
+  assertEquals "home directory" '~' "$lp_path"
   assertEquals "home directory formatting" '{format}~' "$lp_path_format"
 
   PWD="/tmp/_lp/a"
   _lp_path_format ''
+  assertEquals "short directory" "$PWD" "$lp_path"
   assertEquals "short directory formatting" "$PWD" "$lp_path_format"
 
   LP_PATH_LENGTH=1
 
   PWD="/tmp/_lp/a/very"
   _lp_path_format ''
+  assertEquals "short directory" "$PWD" "$lp_path"
   assertEquals "short directory formatting" "$PWD" "$lp_path_format"
 
   PWD="/avery/muchlong/pathname"
@@ -277,6 +297,7 @@ function test_path_format_from_dir_right {
   LP_MARK_SHORTEN_PATH="."
   PWD="/tmp/_lp/a/very/long/pathname"
   _lp_path_format '{n}' '{l}' '{v}' '{s}'
+  assertEquals "full directory" "/t./_./a/very/l./pathname" "$lp_path"
   assertEquals "full directory formatting" "{n}/{s}t./{s}_./{n}a/{v}very/{s}l./{l}pathname" "$lp_path_format"
 
   LP_PATH_KEEP=2
@@ -284,10 +305,12 @@ function test_path_format_from_dir_right {
 
   LP_PATH_LENGTH=31
   _lp_path_format '{n}' '{l}' '{v}' '{s}'
+  assertEquals "full directory length $LP_PATH_LENGTH" "/tmp/a./s./obviouslytoolong/dir" "$lp_path"
   assertEquals "full directory formatting length $LP_PATH_LENGTH" "{n}/{n}tmp/{s}a./{s}s./{n}obviouslytoolong/{l}dir" "$lp_path_format"
 
   LP_PATH_LENGTH=30
   _lp_path_format '{n}' '{l}' '{v}' '{s}'
+  assertEquals "full directory length $LP_PATH_LENGTH" "/tmp/a./s./o./dir" "$lp_path"
   assertEquals "full directory formatting length $LP_PATH_LENGTH" "{n}/{n}tmp/{s}a./{s}s./{s}o./{l}dir" "$lp_path_format"
 }
 
@@ -308,50 +331,61 @@ function test_path_format_from_dir_middle {
   LP_MARK_SHORTEN_PATH="..."
   LP_PATH_CHARACTER_KEEP=1
 
-  typeset lp_path_format
+  typeset lp_path lp_path_format
 
   _lp_path_format '{format}'
+  assertEquals "root directory" '/' "$lp_path"
   assertEquals "root directory formatting" '{format}/' "$lp_path_format"
 
   _lp_path_format '{format}' '' '' '' '['
+  assertEquals "root directory ignore separator" '/' "$lp_path"
   assertEquals "root directory formatting ignore separator" '{format}/' "$lp_path_format"
 
   PWD="/tmp"
   _lp_path_format ''
-  assertEquals "root directory no formatting" '/tmp' "$lp_path_format"
+  assertEquals "tmp directory" '/tmp' "$lp_path"
+  assertEquals "tmp directory no formatting" '/tmp' "$lp_path_format"
 
   _lp_path_format '' '' '' '' '^'
-  assertEquals "root directory no formatting custom separator" '/^tmp' "$lp_path_format"
+  assertEquals "tmp directory custom separator" '/tmp' "$lp_path"
+  assertEquals "tmp directory no formatting custom separator" '/^tmp' "$lp_path_format"
 
   PWD=$HOME
   _lp_path_format '{format}'
+  assertEquals "home directory" '~' "$lp_path"
   assertEquals "home directory formatting" '{format}~' "$lp_path_format"
 
   PWD="/tmp/_lp/a"
   _lp_path_format ''
+  assertEquals "short directory" "$PWD" "$lp_path"
   assertEquals "short directory formatting" "$PWD" "$lp_path_format"
 
   LP_PATH_LENGTH=1
 
   PWD="/tmp/_lp/a/very"
   _lp_path_format ''
+  assertEquals "short directory" "$PWD" "$lp_path"
   assertEquals "short directory formatting" "$PWD" "$lp_path_format"
 
   PWD="/avery/muchlong/pathname"
   _lp_path_format ''
+  assertEquals "short directory" "/avery/m...g/pathname" "$lp_path"
   assertEquals "short directory formatting" "/avery/m...g/pathname" "$lp_path_format"
 
   LP_MARK_SHORTEN_PATH="."
   PWD="/avery/muchlong/pathname"
   _lp_path_format ''
+  assertEquals "short directory" "/a.y/m.g/pathname" "$lp_path"
   assertEquals "short directory formatting" "/a.y/m.g/pathname" "$lp_path_format"
 
   LP_PATH_LENGTH=$(( ${#PWD} - 1 ))
   _lp_path_format ''
+  assertEquals "medium directory" "/a.y/muchlong/pathname" "$lp_path"
   assertEquals "medium directory formatting" "/a.y/muchlong/pathname" "$lp_path_format"
 
   LP_PATH_KEEP=2
   _lp_path_format ''
+  assertEquals "medium directory" "/avery/m.g/pathname" "$lp_path"
   assertEquals "medium directory formatting" "/avery/m.g/pathname" "$lp_path_format"
 
   _lp_find_vcs() {
@@ -361,6 +395,7 @@ function test_path_format_from_dir_middle {
   LP_PATH_KEEP=0
   PWD="/tmp/_lp/a/very/long/pathname"
   _lp_path_format '{n}' '{l}' '{v}' '{s}'
+  assertEquals "full directory" "/tmp/_lp/a/very/l.g/pathname" "$lp_path"
   assertEquals "full directory formatting" "{n}/{n}tmp/{n}_lp/{n}a/{v}very/{s}l.g/{l}pathname" "$lp_path_format"
 
   LP_PATH_KEEP=2
@@ -368,10 +403,12 @@ function test_path_format_from_dir_middle {
 
   LP_PATH_LENGTH=33
   _lp_path_format '{n}' '{l}' '{v}' '{s}'
+  assertEquals "full directory length $LP_PATH_LENGTH" "/tmp/a.g/s.g/obviouslytoolong/dir" "$lp_path"
   assertEquals "full directory formatting length $LP_PATH_LENGTH" "{n}/{n}tmp/{s}a.g/{s}s.g/{n}obviouslytoolong/{l}dir" "$lp_path_format"
 
   LP_PATH_LENGTH=32
   _lp_path_format '{n}' '{l}' '{v}' '{s}'
+  assertEquals "full directory length $LP_PATH_LENGTH" "/tmp/a.g/s.g/o.g/dir" "$lp_path"
   assertEquals "full directory formatting length $LP_PATH_LENGTH" "{n}/{n}tmp/{s}a.g/{s}s.g/{s}o.g/{l}dir" "$lp_path_format"
 }
 
@@ -392,49 +429,60 @@ function test_path_format_unique() {
   LP_PATH_VCS_ROOT=1
   LP_PATH_METHOD=truncate_chars_to_unique_dir
 
-  typeset lp_path_format
+  typeset lp_path lp_path_format
 
   _lp_path_format '{format}'
+  assertEquals "root directory" '/' "$lp_path"
   assertEquals "root directory formatting" '{format}/' "$lp_path_format"
 
   _lp_path_format '{format}' '' '' '' '['
+  assertEquals "root directory ignore separator" '/' "$lp_path"
   assertEquals "root directory formatting ignore separator" '{format}/' "$lp_path_format"
 
   PWD="/tmp"
   _lp_path_format ''
-  assertEquals "root directory no formatting" '/tmp' "$lp_path_format"
+  assertEquals "tmp directory" '/tmp' "$lp_path"
+  assertEquals "tmp directory no formatting" '/tmp' "$lp_path_format"
 
   _lp_path_format '' '' '' '' '^'
-  assertEquals "root directory no formatting custom separator" '/^tmp' "$lp_path_format"
+  assertEquals "tmp directory custom separator" '/tmp' "$lp_path"
+  assertEquals "tmp directory no formatting custom separator" '/^tmp' "$lp_path_format"
 
   PWD=$HOME
   _lp_path_format '{format}'
+  assertEquals "home directory" '~' "$lp_path"
   assertEquals "home directory formatting" '{format}~' "$lp_path_format"
 
   PWD="/tmp/_lp/a"
   _lp_path_format ''
+  assertEquals "short directory" "$PWD" "$lp_path"
   assertEquals "short directory formatting" "$PWD" "$lp_path_format"
 
   LP_PATH_LENGTH=13
 
   PWD="/tmp/_lp/a/very"
   _lp_path_format ''
+  assertEquals "short directory" "/t/_lp/a/very" "$lp_path"
   assertEquals "short directory formatting" "/t/_lp/a/very" "$lp_path_format"
 
   LP_PATH_LENGTH=1
   _lp_path_format '{n}' '{l}' '{v}' '{s}'
+  assertEquals "shortened directory" "/t/_/a/very" "$lp_path"
   assertEquals "shortened directory formatting" "{n}/{s}t/{s}_/{n}a/{l}very" "$lp_path_format"
 
   LP_PATH_LENGTH=13
   _lp_path_format '{n}' '{l}' '{v}' '{s}'
+  assertEquals "medium directory" "/t/_lp/a/very" "$lp_path"
   assertEquals "medium directory formatting" "{n}/{s}t/{n}_lp/{n}a/{l}very" "$lp_path_format"
 
   LP_PATH_KEEP=2
   _lp_path_format '{n}' '{l}' '{v}' '{s}'
+  assertEquals "medium directory" "/tmp/_/a/very" "$lp_path"
   assertEquals "medium directory formatting" "{n}/{n}tmp/{s}_/{n}a/{l}very" "$lp_path_format"
 
   LP_PATH_KEEP=3
   _lp_path_format '{n}' '{l}' '{v}' '{s}'
+  assertEquals "medium directory" "/tmp/_lp/a/very" "$lp_path"
   assertEquals "medium directory formatting" "{n}/{n}tmp/{n}_lp/{n}a/{l}very" "$lp_path_format"
 
   _lp_find_vcs() {
@@ -444,9 +492,11 @@ function test_path_format_unique() {
   LP_PATH_KEEP=0
   PWD="/tmp/_lp/a/very/long/pathname"
   _lp_path_format '{n}' '{l}' '{v}' '{s}'
+  assertEquals "full directory " "/t/_/a/very/l/pathname" "$lp_path"
   assertEquals "full directory formatting" "{n}/{s}t/{s}_/{n}a/{v}very/{s}l/{l}pathname" "$lp_path_format"
 
   _lp_path_format '{n}' '{l}' '{v}' '{s}' '^' '{^}'
+  assertEquals "full directory with separator" "/t/_/a/very/l/pathname" "$lp_path"
   assertEquals "full directory formatting with separator" "{n}/{^}^{s}t{^}^{s}_{^}^{n}a{^}^{v}very{^}^{s}l{^}^{l}pathname" "$lp_path_format"
 
   pathTearDown
@@ -464,38 +514,43 @@ function test_path_format_last_dir() {
   LP_PATH_VCS_ROOT=1
   LP_PATH_METHOD=truncate_to_last_dir
 
-  typeset lp_path_format
+  typeset lp_path lp_path_format
 
   _lp_path_format '{format}'
+  assertEquals "root directory" '/' "$lp_path"
   assertEquals "root directory formatting" '{format}/' "$lp_path_format"
 
   _lp_path_format '{format}' '' '' '' '['
+  assertEquals "root directory ignore separator" '/' "$lp_path"
   assertEquals "root directory formatting ignore separator" '{format}/' "$lp_path_format"
 
   PWD="/tmp"
   _lp_path_format ''
-  assertEquals "root directory no formatting" 'tmp' "$lp_path_format"
+  assertEquals "tmp directory" 'tmp' "$lp_path"
+  assertEquals "tmp directory no formatting" 'tmp' "$lp_path_format"
 
   _lp_path_format '' '' '' '' '^'
-  assertEquals "root directory no formatting custom separator" 'tmp' "$lp_path_format"
+  assertEquals "tmp directory no custom separator" 'tmp' "$lp_path"
+  assertEquals "tmp directory no formatting custom separator" 'tmp' "$lp_path_format"
 
   PWD=$HOME
   _lp_path_format '{format}'
+  assertEquals "home directory" '~' "$lp_path"
   assertEquals "home directory formatting" '{format}~' "$lp_path_format"
 
   PWD="/tmp/_lp/a"
   _lp_path_format ''
+  assertEquals "short directory" "a" "$lp_path"
   assertEquals "short directory formatting" "a" "$lp_path_format"
 
   PWD="/tmp/_lp/a/very"
   _lp_path_format ''
+  assertEquals "short directory" "very" "$lp_path"
   assertEquals "short directory formatting" "very" "$lp_path_format"
 
   _lp_path_format '{n}' '{l}' '{v}' '{s}'
+  assertEquals "shortened directory" "very" "$lp_path"
   assertEquals "shortened directory formatting" "{l}very" "$lp_path_format"
-
-  _lp_path_format '{n}' '{l}' '{v}' '{s}'
-  assertEquals "medium directory formatting" "{l}very" "$lp_path_format"
 
   _lp_find_vcs() {
     lp_vcs_root="$PWD"
@@ -503,14 +558,17 @@ function test_path_format_last_dir() {
 
   PWD="/tmp/_lp/a/very"
   _lp_path_format '{n}' '{l}' '{v}' '{s}'
+  assertEquals "full directory vcs" "very" "$lp_path"
   assertEquals "full directory vcs formatting" "{v}very" "$lp_path_format"
 
   LP_PATH_VCS_ROOT=0
   _lp_path_format '{n}' '{l}' '{v}' '{s}'
+  assertEquals "full directory" "very" "$lp_path"
   assertEquals "full directory formatting" "{l}very" "$lp_path_format"
 
   PWD="/tmp/_lp/a/very/long/pathname"
   _lp_path_format '{n}' '{l}' '{v}' '{s}' '^' '{^}'
+  assertEquals "full directory with separator" "pathname" "$lp_path"
   assertEquals "full directory formatting with separator" "{l}pathname" "$lp_path_format"
 }
 

--- a/themes/powerline/powerline.theme
+++ b/themes/powerline/powerline.theme
@@ -97,8 +97,8 @@ _lp_powerline_theme_prompt() {
 
         local lp_vcs_stash_count
         if _lp_vcs_stash_count; then
-            __powerline_sub_section_arrow -2
-            powerline_sections+=$sub_section_arrow
+            __powerline_sub_section_format -2
+            powerline_sections+="${sub_section_format}${POWERLINE_SOFT_DIVIDER}"
 
             __powerline_section "${POWERLINE_STASH_MARKER} ${lp_vcs_stash_count}" "${POWERLINE_VCS_STASH_COLOR[@]}"
         fi
@@ -270,39 +270,10 @@ __powerline_section_arrow() {  # _, background_color, _, _, _, fallback_backgrou
     fi
 }
 
-__powerline_sub_section_arrow() {  # foreground_color, _, _, _, fallback_foreground_color
+__powerline_sub_section_format() {  # foreground_color, _, _, _, fallback_foreground_color
     local lp_terminal_format
     lp_terminal_format "${1-}" -2 0 0 "${5-}"
-    sub_section_arrow="${lp_terminal_format}${POWERLINE_SOFT_DIVIDER}"
-}
-
-__powerline_path_split() {  # path_format, [separator_format], [last_dir_format]
-    lp_terminal_format "${POWERLINE_PATH_COLOR[@]}"
-    local path_format=$lp_terminal_format
-
-    local sub_section_arrow
-    __powerline_sub_section_arrow "${POWERLINE_PATH_SEPARATOR_COLOR[@]}"
-    local separator="${POWERLINE_SPACER}${sub_section_arrow}"
-
-    lp_terminal_format "${POWERLINE_PATH_LAST_COLOR[@]}"
-    local last_dir_format=$lp_terminal_format
-
-    local path_start=${lp_path%/*} path_end=${lp_path##*/}
-
-    # If the path is only / or doesn't contain one (if the path is ~),
-    # no separators are needed.
-    if [[ $lp_path != '/' && $lp_path == *'/'* ]]; then
-        local leader=
-        if [[ ${lp_path:0:1} == '/' ]]; then
-            # The replace would treat the leading / as a separator, and not show
-            # it at all. Powerline treats the leading / as a directory (as it is).
-            leader='/'
-        fi
-        powerline_path="${path_format}${POWERLINE_SPACER}${leader}${path_start//\//${separator}${path_format}${POWERLINE_SPACER}}${separator}"
-    fi
-
-    # If path_end is empty, the path was only /
-    powerline_path+="${last_dir_format}${POWERLINE_SPACER}${path_end:-/}${POWERLINE_SPACER}"
+    sub_section_format="${lp_terminal_format}"
 }
 
 # This cannot use __powerline_section() as we generate colors inside
@@ -311,8 +282,22 @@ __powerline_path_split() {  # path_format, [separator_format], [last_dir_format]
 __powerline_path_section() {
     local powerline_path section_arrow
     __powerline_section_arrow "${POWERLINE_PATH_COLOR[@]}"
-    __powerline_path_split
-    powerline_sections+=${section_arrow}${powerline_path}
+
+    lp_terminal_format "${POWERLINE_PATH_COLOR[@]}"
+    local path_format=$lp_terminal_format
+
+    local sub_section_format
+    __powerline_sub_section_format "${POWERLINE_PATH_SEPARATOR_COLOR[@]}"
+    local separator_format=$sub_section_format
+
+    lp_terminal_format "${POWERLINE_PATH_LAST_COLOR[@]}"
+    local last_dir_format=$lp_terminal_format
+
+    local lp_path_format
+    _lp_path_format "$path_format" "$last_dir_format" "" '' \
+        "${POWERLINE_SPACER}${POWERLINE_SOFT_DIVIDER}${POWERLINE_SPACER}" "$separator_format"
+
+    powerline_sections+="${section_arrow}${POWERLINE_SPACER}${lp_path_format}${POWERLINE_SPACER}"
 }
 
 # Is this a dirty hack? Yes. Am I proud of it? Also yes.

--- a/themes/powerline/powerline.theme
+++ b/themes/powerline/powerline.theme
@@ -17,6 +17,8 @@ _lp_powerline_theme_activate() {
     [[ -z ${POWERLINE_PATH_COLOR[@]+x}           ]] && POWERLINE_PATH_COLOR=(250 240 0 0 7 0)
     [[ -z ${POWERLINE_PATH_SEPARATOR_COLOR[@]+x} ]] && POWERLINE_PATH_SEPARATOR_COLOR=(245 240 0 0 7 0)
     [[ -z ${POWERLINE_PATH_LAST_COLOR[@]+x}      ]] && POWERLINE_PATH_LAST_COLOR=(252 240 1 0 7 0)
+    [[ -z ${POWERLINE_PATH_VCS_COLOR[@]+x}       ]] && POWERLINE_PATH_VCS_COLOR=(147 240 1 0 4 0)
+    [[ -z ${POWERLINE_PATH_SHORTENED_COLOR[@]+x} ]] && POWERLINE_PATH_SHORTENED_COLOR=(245 240 0 0 7 0)
     [[ -z ${POWERLINE_JOBS_COLOR[@]+x}           ]] && POWERLINE_JOBS_COLOR=(220 166 0 0 3 2)
     [[ -z ${POWERLINE_VCS_CLEAN_COLOR[@]+x}      ]] && POWERLINE_VCS_CLEAN_COLOR=(250 236 0 0 7 0)
     [[ -z ${POWERLINE_VCS_DIRTY_COLOR[@]+x}      ]] && POWERLINE_VCS_DIRTY_COLOR=(220 236 0 0 3 0)
@@ -58,6 +60,9 @@ _lp_powerline_theme_directory() {
         title+="@${_POWERLINE_HOSTNAME}"
     fi
 
+    local lp_path
+    __powerline_path_generate
+
     [[ -n $title ]] && title+=":"
     title+="${lp_path}"
 
@@ -76,7 +81,7 @@ _lp_powerline_theme_prompt() {
         __powerline_section "${POWERLINE_PYTHON_ENV_MARKER}${lp_python_env}" "${POWERLINE_PYTHON_ENV_COLOR[@]}"
     fi
 
-    __powerline_path_section
+    __powerline_section "$_lp_powerline_path" "${POWERLINE_PATH_COLOR[@]}"
 
     local lp_running_jobs lp_stopped_jobs
     if _lp_jobcount; then
@@ -182,7 +187,7 @@ _lp_powerline_full_theme_prompt() {
 
     __powerline_section "${_POWERLINE_HOST_ICON}${_POWERLINE_HOSTNAME}" "${POWERLINE_HOST_COLOR[@]}"
 
-    __powerline_path_section
+    __powerline_section "$_lp_powerline_path" "${POWERLINE_PATH_COLOR[@]}"
 
     if _lp_dirstack; then
         __powerline_section "${LP_MARK_DIRSTACK}${lp_dirstack}" "${POWERLINE_DIRSTACK_COLOR[@]}"
@@ -276,28 +281,31 @@ __powerline_sub_section_format() {  # foreground_color, _, _, _, fallback_foregr
     sub_section_format="${lp_terminal_format}"
 }
 
-# This cannot use __powerline_section() as we generate colors inside
-# __powerline_path_split(), which forgets the old colors for the arrow. This
-# function lets the arrow go first.
-__powerline_path_section() {
-    local powerline_path section_arrow
-    __powerline_section_arrow "${POWERLINE_PATH_COLOR[@]}"
+# We don't want to generate the path every prompt, so create the full formatted
+# path once for each dir.
+__powerline_path_generate() {
+    local lp_terminal_format sub_section_format _lp_last_af_color _lp_last_ab_color
 
     lp_terminal_format "${POWERLINE_PATH_COLOR[@]}"
     local path_format=$lp_terminal_format
 
-    local sub_section_format
     __powerline_sub_section_format "${POWERLINE_PATH_SEPARATOR_COLOR[@]}"
     local separator_format=$sub_section_format
+
+    lp_terminal_format "${POWERLINE_PATH_SHORTENED_COLOR[@]}"
+    local shortened_format=$lp_terminal_format
+
+    lp_terminal_format "${POWERLINE_PATH_VCS_COLOR[@]}"
+    local vcs_format=$lp_terminal_format
 
     lp_terminal_format "${POWERLINE_PATH_LAST_COLOR[@]}"
     local last_dir_format=$lp_terminal_format
 
     local lp_path_format
-    _lp_path_format "$path_format" "$last_dir_format" "" '' \
+    _lp_path_format "$path_format" "$last_dir_format" "$vcs_format" "$shortened_format" \
         "${POWERLINE_SPACER}${POWERLINE_SOFT_DIVIDER}${POWERLINE_SPACER}" "$separator_format"
 
-    powerline_sections+="${section_arrow}${POWERLINE_SPACER}${lp_path_format}${POWERLINE_SPACER}"
+    _lp_powerline_path=${lp_path_format}
 }
 
 # Is this a dirty hack? Yes. Am I proud of it? Also yes.


### PR DESCRIPTION
Drop `__lp_path()`, `__lp_shorten_path()`, and `__lp_set_dirtrim()`. That method of path generation had two major flaws:

1. It did not allow for formatting to be injected into the path. While shorten_path() could have been modified to work eventually, it was starting off on the wrong foot, and dirtrim could never support it, since we were letting Bash handle the shortening.
2. Since some of the methods let the shortening happen outside the prompt, and when shortening was disabled would always let the shell handle path display, there was no way to solve the two connected issues of Ksh support and title display outside of PS1.

To fix both of these issues, the solution is simple. Make all path display go through the prompt, which allows for formatting even if not shortening.

This rather large PR does exactly that: adds a new data source `_lp_path_format()`, which supports all previous path shortening methods, as well as adding 3 new ones. It also supports highlighting the VCS root directory, resolving #149 and #349.

A large part of this diff is extensive tests and documentation.

The "removed" features have compatibility shims, to hopefully make users of these less common path options not notice any changes, while still getting the benefits of the new formatting where possible.