### PR TITLE
Add Github action for linting documentation

### DIFF
--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -1,0 +1,24 @@
+name: Lint Documentation
+on:
+  push:
+    paths:
+      - 'docs/**'
+  pull_request:
+jobs:
+  docs-lint:
+    name: Lint Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+      - name: Lint
+        run: |
+          cd docs/
+          python3 -m pip install -r requirements.txt
+          make dummy
+          make linkcheck


### PR DESCRIPTION
Simply runs the Sphinx output targets for linting (dummy), which compiles the docs without outputting anything, and checking that all links are valid.

I wasn't going to open a PR for this one, but since I included a rule to only run this on changes to `docs/`, it wouldn't run.