### PR TITLE
Zinit setup documentation

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -35,6 +35,15 @@ following line in your ``.zshrc`` after activating Antigen::
 
    antigen bundle nojhan/liquidprompt
 
+Installation via Zinit
+----------------------
+
+To install via `Zinit <https://github.com/zdharma/zinit>`_, simply add the
+following lines in your ``.zshrc`` after activating Zinit::
+
+    zinit ice ver"stable" lucid nocd
+    zinit light nojhan/liquidprompt
+
 Dependencies
 ============
 


### PR DESCRIPTION
This change adds instructions on how to load liquidprompt using `zinit
load`, then provides an additional config which makes use of zinit's "ice modifiers" to:

 - ~Only load the prompt if the shell is marked as interactive (The 'i' in `$-`): `load'[[ $- = *i* ]]'`~
 - ~Reset the prompt after loading the snippet: `wait'!'`~
 - Hide the default loading message: `lucid`
 - Don't change the directory when loading the plugin: `nocd`

After some testing, it became clear that the most idomatic configuration was probably not the best default for most users, and so it was simplified.

It also makes use of `zinit light` instead of `zinit load`, which is faster because it does not attempt to monitor or profile the execution of the plugin.

