### PR TITLE
Shell escapes, command titles, and related fixes

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,6 +39,9 @@ man_pages = [
     ('theme', 'liquidprompt', 'Liquidprompt theming', [], 7),
 ]
 
+# A URL to cross-reference manpage directives
+manpages_url = 'https://manpages.debian.org/{path}'
+
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -531,6 +531,17 @@ Features
    .. warning::
       This may not work properly on exotic terminals. Please report any issues.
 
+.. attribute:: LP_ENABLE_TITLE_COMMAND
+   :type: bool
+   :value: 1
+
+   Postpend the currently running command to the terminal title while the
+   command is running.
+
+   :attr:`LP_ENABLE_TITLE` must be enabled to have any effect.
+
+   .. versionadded:: 2.1
+
 .. attribute:: LP_ENABLE_VCS_ROOT
    :type: bool
    :value: 0

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -174,6 +174,17 @@ General
    A string displayed at the start of the prompt. Can also be set with
    :func:`prompt_tag`.
 
+.. attribute:: LP_TIME_FORMAT
+   :type: string
+   :value: "%H:%M:%S"
+
+   The formatting string passed to :manpage:`date(1)` using formatting from
+   :manpage:`strftime(3)` used to display the current date and/or time.
+
+   See also: :attr:`LP_ENABLE_TIME`.
+
+   .. versionadded:: 2.1
+
 Features
 --------
 
@@ -503,7 +514,8 @@ Features
    :type: bool
    :value: 0
 
-   Displays the time at which the prompt was shown.
+   Displays the time at which the prompt was shown. The format can be configured
+   with :attr:`LP_TIME_FORMAT`.
 
    See also: :attr:`LP_TIME_ANALOG` and :attr:`LP_COLOR_TIME`.
 

--- a/docs/functions/data.rst
+++ b/docs/functions/data.rst
@@ -256,18 +256,13 @@ OS
 
    Returns the hostname string.
 
-   .. note::
-
-      The returned string is not the real hostname, instead it is the shell
-      escape code for hostname, so the shell will substitute the real user ID
-      when it evaluates :envvar:`PS1`.
-
-   .. deprecated:: 2.0
-      Also sets :attr:`LP_HOST_SYMBOL` to the same return string.
-
    Can be disabled by :attr:`LP_HOSTNAME_ALWAYS` set to ``-1``.
 
    .. versionadded:: 2.0
+
+   .. versionchanged:: 2.1
+      Returns the actual hostname instead of a shell prompt escape code.
+      No longer sets :attr:`LP_HOST_SYMBOL` to the same return string.
 
 .. function:: _lp_sudo_active()
 

--- a/docs/functions/data.rst
+++ b/docs/functions/data.rst
@@ -296,15 +296,12 @@ OS
 
    Returns the current user ID.
 
-   .. note::
-
-      The returned string is not a real user ID, instead it is the shell escape
-      code for user, so the shell will substitute the real user ID when it
-      evaluates :envvar:`PS1`.
-
    Can be disabled by :attr:`LP_USER_ALWAYS` set to ``-1``.
 
    .. versionadded:: 2.0
+
+   .. versionchanged:: 2.1
+      Returns the actual username instead of a shell prompt escape code.
 
 Path
 ----

--- a/docs/functions/data.rst
+++ b/docs/functions/data.rst
@@ -386,25 +386,22 @@ Time
 .. function:: _lp_time() -> var:lp_time
 
    Returns ``true`` if digital time is enabled. Returns the current digital time
-   string.
+   string, formatting set by :attr:`LP_TIME_FORMAT`.
 
-   .. note::
-
-      The returned string is not the real time, instead it is the shell escape
-      code for time, so the shell will substitute the real current time when it
-      evaluates :envvar:`PS1`.
-
-   Can be disabled by :attr:`LP_ENABLE_TIME` or :attr:`LP_TIME_ANALOG` set to
+   Can be disabled by :attr:`LP_ENABLE_TIME`, or :attr:`LP_TIME_ANALOG` set to
    ``1``.
 
    .. versionadded:: 2.0
+
+   .. versionchanged:: 2.1
+      Returns the actual time instead of a shell prompt escape code.
 
 .. function:: _lp_analog_time() -> var:lp_analog_time
 
    Returns ``true`` if analog time is enabled. Returns the current analog time
    as a single Unicode character, accurate to the closest 30 minutes.
 
-   Can be disabled by :attr:`LP_ENABLE_TIME` or :attr:`LP_TIME_ANALOG` set to
+   Can be disabled by :attr:`LP_ENABLE_TIME`, or :attr:`LP_TIME_ANALOG` set to
    ``0``.
 
    .. versionadded:: 2.0

--- a/docs/functions/data.rst
+++ b/docs/functions/data.rst
@@ -249,12 +249,15 @@ OS
 
    .. versionadded:: 2.0
 
-.. function:: _lp_hostname() -> var:lp_hostname
+.. function:: _lp_hostname() -> var:lp_hostname, var:lp_hostname_raw
 
    Returns ``true`` if a hostname should be displayed. Returns ``1`` if the
    connection type is local and :attr:`LP_HOSTNAME_ALWAYS` is not ``1``.
 
-   Returns the hostname string.
+   Returns the hostname string in *lp_hostname*.
+
+   Returns the hostname string not passed through :func:`__lp_escape` in
+   *lp_hostname_raw*.
 
    Can be disabled by :attr:`LP_HOSTNAME_ALWAYS` set to ``-1``.
 
@@ -262,6 +265,7 @@ OS
 
    .. versionchanged:: 2.1
       Returns the actual hostname instead of a shell prompt escape code.
+      Added *lp_hostname_raw* return value.
       No longer sets :attr:`LP_HOST_SYMBOL` to the same return string.
 
 .. function:: _lp_sudo_active()
@@ -284,12 +288,15 @@ OS
 
    .. versionadded:: 2.0
 
-.. function:: _lp_username() -> var:lp_username
+.. function:: _lp_username() -> var:lp_username, var:lp_username_raw
 
    Returns ``true`` if a username should be displayed. Returns ``1`` if the
    user is the login user and :attr:`LP_USER_ALWAYS` is not ``1``.
 
-   Returns the current user ID.
+   Returns the current user ID in *lp_username*.
+
+   Returns the current user ID not passed through :func:`__lp_escape` in
+   *lp_username_raw*.
 
    Can be disabled by :attr:`LP_USER_ALWAYS` set to ``-1``.
 
@@ -297,6 +304,7 @@ OS
 
    .. versionchanged:: 2.1
       Returns the actual username instead of a shell prompt escape code.
+      Added *lp_username_raw* return value.
 
 Path
 ----
@@ -307,9 +315,10 @@ Path
    [separator_format]) -> var:lp_path, var:lp_path_format
 
    Returns a shortened and formatted string indicating the current working
-   directory path. *lp_path* contains the path without any formatting or custom
-   separators, intended for use in the terminal title. *lp_path_format* contains
-   the complete formatted path, to be inserted into the prompt.
+   directory path. *lp_path* contains the path without any formatting, custom
+   separators, or shell escapes, intended for use in the terminal title.
+   *lp_path_format* contains the complete formatted path, to be inserted into
+   the prompt.
 
    The behavior of the shortening is controlled by
    :attr:`LP_ENABLE_SHORTEN_PATH`, :attr:`LP_PATH_METHOD`,
@@ -338,6 +347,9 @@ Path
    a directory, and is formatted as such.
 
    .. versionadded:: 2.0
+
+   .. versionchanged:: 2.1
+      Changed *lp_path* to no longer contain shell escapes.
 
 Runtime
 -------

--- a/docs/functions/internal.rst
+++ b/docs/functions/internal.rst
@@ -155,6 +155,14 @@ Path
 Prompt
 ------
 
+.. function:: __lp_before_command()
+
+   Used only by Bash to hack the DEBUG trap to run functions before the user
+   command executes.
+
+   .. versionchanged:: 2.1
+      Renamed from the Bash version of ``__lp_runtime_before``.
+
 .. function:: __lp_set_prompt()
 
    Setup features that need to be handled outside of the themes, like
@@ -179,8 +187,9 @@ Runtime
 
 .. function:: __lp_runtime_after()
 
-   Hooks into the shell to run directly after the user command returns, to
-   record the current time, and calculate how long the command ran for.
+   Called by :func:`__lp_set_prompt` to run directly after the user command
+   returns, to record the current time and calculate how long the command ran
+   for.
 
    .. versionchanged:: 2.0
       Renamed from ``_lp_runtime_after``.
@@ -208,6 +217,22 @@ Theme
    :func:`lp_theme`.
 
    .. versionadded:: 2.0
+
+Title
+-----
+
+.. function:: __lp_get_last_command_line() -> var:command
+
+   Returns the whole command line most recently submitted by the user.
+
+   .. versionadded:: 2.1
+
+.. function:: __lp_print_title_command()
+
+   Sets the terminal title to the normal set title, postpended with the
+   currently running command.
+
+   .. versionadded:: 2.1
 
 Temperature
 -----------

--- a/liquidprompt
+++ b/liquidprompt
@@ -39,7 +39,6 @@ if test -n "${BASH_VERSION-}"; then
     _LP_USER_SYMBOL="\u"
     _LP_HOST_SYMBOL="\h"
     _LP_FQDN_SYMBOL="\H"
-    _LP_TIME_SYMBOL="\t"
     _LP_MARK_SYMBOL='$'
 
     _LP_FIRST_INDEX=0
@@ -71,7 +70,6 @@ elif test -n "${ZSH_VERSION-}" ; then
     _LP_USER_SYMBOL="%n"
     _LP_HOST_SYMBOL="%m"
     _LP_FQDN_SYMBOL="%M"
-    _LP_TIME_SYMBOL="%*"
     _LP_MARK_SYMBOL='%%'
 
     _LP_FIRST_INDEX=1
@@ -177,6 +175,7 @@ __lp_source_config() {
 
 
     # Default values (globals)
+    LP_TIME_FORMAT=${LP_TIME_FORMAT:-"%H:%M:%S"}
     LP_BATTERY_THRESHOLD=${LP_BATTERY_THRESHOLD:-75}
     LP_LOAD_THRESHOLD=${LP_LOAD_THRESHOLD:-0.60}
     LP_LOAD_CAP=${LP_LOAD_CAP:-2.0}
@@ -2618,13 +2617,15 @@ _lp_analog_time_color() {
 _lp_time() {
     (( LP_ENABLE_TIME && ! LP_TIME_ANALOG )) || return 2
 
-    lp_time=${_LP_TIME_SYMBOL}
+    local ret
+    __lp_escape "$(date "+${LP_TIME_FORMAT}")"
+    lp_time=$ret
 }
 
 _lp_time_color() {
     _lp_time || return "$?"
 
-    lp_time_color="${LP_COLOR_TIME}${_LP_TIME_SYMBOL}${NO_COL}"
+    lp_time_color="${LP_COLOR_TIME}${lp_time}${NO_COL}"
 }
 
 #################
@@ -2670,12 +2671,6 @@ _lp_default_theme_activate() {
 
     _lp_terminal_device
     LP_TTYN=$lp_terminal_device
-
-    if _lp_time_color; then
-        LP_TIME="${lp_time_color} "
-    else
-        LP_TIME=
-    fi
 }
 
 _lp_default_theme_directory() {
@@ -2720,8 +2715,12 @@ _lp_default_theme_prompt_data() {
         LP_BATT=
     fi
 
-    if _lp_analog_time_color; then
+    if _lp_time_color; then
+        LP_TIME="$lp_time_color "
+    elif _lp_analog_time_color; then
         LP_TIME="$lp_analog_time_color "
+    else
+        LP_TIME=
     fi
 
     if _lp_sudo_active_color; then

--- a/liquidprompt
+++ b/liquidprompt
@@ -40,7 +40,7 @@ if test -n "${BASH_VERSION-}"; then
     _LP_HOST_SYMBOL="\h"
     _LP_FQDN_SYMBOL="\H"
     _LP_TIME_SYMBOL="\t"
-    _LP_MARK_SYMBOL='\$'
+    _LP_MARK_SYMBOL='$'
 
     _LP_FIRST_INDEX=0
     _LP_PERCENT='%'    # must be escaped on zsh
@@ -72,7 +72,7 @@ elif test -n "${ZSH_VERSION-}" ; then
     _LP_HOST_SYMBOL="%m"
     _LP_FQDN_SYMBOL="%M"
     _LP_TIME_SYMBOL="%*"
-    _LP_MARK_SYMBOL='%(!.#.%%)'
+    _LP_MARK_SYMBOL='%%'
 
     _LP_FIRST_INDEX=1
     _LP_PERCENT='%%'
@@ -556,6 +556,8 @@ lp_activate() {
         if (( ! LP_ENABLE_VCS_ROOT )); then
             LP_DISABLED_VCS_PATHS=("/")
         fi
+
+        LP_MARK_DEFAULT='#'
 
         LP_COLOR_MARK=$LP_COLOR_MARK_ROOT
         LP_COLOR_PATH=$LP_COLOR_PATH_ROOT

--- a/liquidprompt
+++ b/liquidprompt
@@ -212,6 +212,7 @@ __lp_source_config() {
     LP_ENABLE_VCS_ROOT=${LP_ENABLE_VCS_ROOT:-0}
     LP_ENABLE_TITLE=${LP_ENABLE_TITLE:-0}
     LP_ENABLE_SCREEN_TITLE=${LP_ENABLE_SCREEN_TITLE:-0}
+    LP_ENABLE_TITLE_COMMAND=${LP_ENABLE_TITLE_COMMAND:-1}
     LP_ENABLE_SSH_COLORS=${LP_ENABLE_SSH_COLORS:-0}
     LP_ENABLE_FQDN=${LP_ENABLE_FQDN:-0}
     LP_DISABLED_VCS_PATHS=( ${LP_DISABLED_VCS_PATHS[@]+"${LP_DISABLED_VCS_PATHS[@]}"} )
@@ -391,10 +392,10 @@ __lp_source_config() {
 # Initialize features based on the user config.
 lp_activate() {
     if (( _LP_SHELL_bash )); then
-        # Disable the DEBUG trap used by the RUNTIME feature
+        # Disable the DEBUG trap used by the RUNTIME or TITLE_COMMAND features
         # (in case we are reloading LP in the same shell after disabling
         # the feature in .liquidpromptrc)
-        (( ${LP_ENABLE_RUNTIME-0} || ${LP_ENABLE_RUNTIME_BELL-0} )) && trap - DEBUG
+        (( ${LP_ENABLE_RUNTIME-0} || ${LP_ENABLE_RUNTIME_BELL-0} || ${LP_ENABLE_TITLE_COMMAND-0} )) && trap - DEBUG
 
         complete -F __lp_theme_bash_complete lp_theme
     else # zsh
@@ -406,7 +407,7 @@ lp_activate() {
         {
             add-zsh-hook -d precmd  __lp_set_prompt
             add-zsh-hook -d preexec __lp_runtime_before
-            add-zsh-hook -d precmd  __lp_runtime_after
+            add-zsh-hook -d preexec __lp_print_title_command
         } >/dev/null
 
         # Enable the autocomplete if the autocomplete system is initialized.
@@ -510,6 +511,9 @@ lp_activate() {
 
     [[ "_${TERM-}" == _linux* ]] && LP_ENABLE_TITLE=0
 
+    # Can not show title command if the title feature is disabled.
+    (( LP_ENABLE_TITLE )) || LP_ENABLE_TITLE_COMMAND=0
+
     # update_terminal_cwd is a shell function available on MacOS X Lion that
     # will update an icon of the directory displayed in the title of the terminal
     # window.
@@ -562,16 +566,16 @@ lp_activate() {
 
     _LP_RUNTIME_LAST_SECONDS=$SECONDS
 
-    if (( LP_ENABLE_RUNTIME || LP_ENABLE_RUNTIME_BELL)); then
-        if (( _LP_SHELL_zsh )); then
-            add-zsh-hook preexec __lp_runtime_before
-            add-zsh-hook precmd  __lp_runtime_after
-        else
+    if (( _LP_SHELL_zsh )); then
+        (( LP_ENABLE_RUNTIME || LP_ENABLE_RUNTIME_BELL )) && add-zsh-hook preexec __lp_runtime_before
+        (( LP_ENABLE_TITLE_COMMAND )) && add-zsh-hook preexec __lp_print_title_command
+    else
+        if (( LP_ENABLE_RUNTIME || LP_ENABLE_RUNTIME_BELL || LP_ENABLE_TITLE_COMMAND )); then
             _LP_AT_PROMPT=0
-            # __lp_runtime_before gets called just before bash executes a command,
+            # __lp_before_command gets called just before bash executes a command,
             # including $PROMPT_COMMAND
             # Pass $_ to this call, because it sets $_ to what it already was
-            trap '__lp_runtime_before "$_"' DEBUG
+            trap '__lp_before_command "$_"' DEBUG
         fi
     fi
 
@@ -2375,29 +2379,10 @@ _lp_runtime_format() {
     fi
 }
 
-if (( _LP_SHELL_zsh )); then
-    __lp_runtime_before() {
-      _LP_RUNTIME_LAST_SECONDS=$SECONDS
-    }
-else
-    __lp_runtime_before() {
-        # For debugging
-        #echo "XXX $BASH_COMMAND"
-
-        # If this is the first time after the user submitted the command,
-        # record the time
-        if (( _LP_AT_PROMPT )); then
-            _LP_RUNTIME_SECONDS=-1 _LP_RUNTIME_LAST_SECONDS=$SECONDS _LP_AT_PROMPT=0
-        fi
-        # If this is when the prompt is being drawn, the command is done,
-        # so calculate the time. Note these two events could be at the same
-        # time, so no elif is used
-        if [[ "$BASH_COMMAND" == "${PROMPT_COMMAND-}" ]]; then
-            _LP_AT_PROMPT=1
-            __lp_runtime_after
-        fi
-    }
-fi
+__lp_runtime_before() {
+    _LP_RUNTIME_LAST_SECONDS=$SECONDS
+    _LP_RUNTIME_SECONDS=-1
+}
 
 # Compute number of seconds since the command was started
 __lp_runtime_after() {
@@ -2584,6 +2569,29 @@ lp_title() {
     else
         unset _lp_manual_title
     fi
+}
+
+if (( _LP_SHELL_zsh )); then
+    __lp_get_last_command_line() {
+        command=$history[$HISTCMD]
+    }
+else
+    __lp_get_last_command_line() {
+        command=$(HISTTIMEFORMAT= builtin history 1 2>/dev/null)
+        command=${command#*[[:digit:]][* ] }
+
+        # Fallback measure if something goes wrong.
+        if [[ -z $command ]]; then
+            command=$BASH_COMMAND
+        fi
+    }
+fi
+
+__lp_print_title_command() {
+    local command
+    __lp_get_last_command_line
+
+    printf '%s' "${LP_TITLE_OPEN}${_lp_manual_title:-${_lp_generated_title-${SHELL+"$SHELL \$ "}}}${command}${LP_TITLE_CLOSE}"
 }
 
 ###################
@@ -2851,6 +2859,10 @@ __lp_set_prompt() {
     #TODO: unused?
     local GREP_OPTIONS=
 
+    if (( LP_ENABLE_RUNTIME || LP_ENABLE_RUNTIME_BELL )); then
+        __lp_runtime_after
+    fi
+
     # bash: execute the old prompt hook
     eval "$LP_OLD_PROMPT_COMMAND"
 
@@ -2878,8 +2890,35 @@ __lp_set_prompt() {
     "$_LP_THEME_PROMPT_FUNCTION"
 
     if (( LP_ENABLE_TITLE )); then
-        PS1="${_LP_OPEN_ESC}${LP_TITLE_OPEN}${_lp_manual_title:-${_lp_generated_title-${SHELL-}}}${LP_TITLE_CLOSE}${_LP_CLOSE_ESC}${PS1}"
+        printf '%s' "${LP_TITLE_OPEN}${_lp_manual_title:-${_lp_generated_title-${SHELL-}}}${LP_TITLE_CLOSE}"
     fi
+}
+
+__lp_before_command() {
+    # For debugging
+    #printf 'XXX %s\n' "$BASH_COMMAND"
+
+    # If this is the first time after the user submitted the command,
+    # execute the hooks.
+    if (( _LP_AT_PROMPT )); then
+        _LP_AT_PROMPT=0
+
+        if (( LP_ENABLE_RUNTIME || LP_ENABLE_RUNTIME_BELL )); then
+            __lp_runtime_before
+        fi
+
+        if (( LP_ENABLE_TITLE_COMMAND )); then
+            __lp_print_title_command
+        fi
+    fi
+
+    # If this is when the prompt is being drawn, the command is done,
+    # so mark the next trap. Note these two events could be at the same
+    # time, so no elif is used.
+    if [[ "$BASH_COMMAND" == __lp_set_prompt ]]; then
+        _LP_AT_PROMPT=1
+    fi
+
 }
 
 prompt_tag() {

--- a/liquidprompt
+++ b/liquidprompt
@@ -73,8 +73,7 @@ elif test -n "${ZSH_VERSION-}" ; then
     _LP_CLEAN_ESC='%\{([^%]+|%[^}])*%\}'
 
     __lp_escape() {
-        local arg="${1//\\/\\\\}"
-        ret="${arg//\%/$_LP_PERCENT}"
+        ret="${1//\%/$_LP_PERCENT}"
     }
 else
     echo "liquidprompt: shell not supported" >&2

--- a/liquidprompt
+++ b/liquidprompt
@@ -36,8 +36,6 @@ if test -n "${BASH_VERSION-}"; then
     _LP_OPEN_ESC="\["
     _LP_CLOSE_ESC="\]"
 
-    _LP_HOST_SYMBOL="\h"
-    _LP_FQDN_SYMBOL="\H"
     _LP_MARK_SYMBOL='$'
 
     _LP_FIRST_INDEX=0
@@ -66,8 +64,6 @@ elif test -n "${ZSH_VERSION-}" ; then
     _LP_OPEN_ESC="%{"
     _LP_CLOSE_ESC="%}"
 
-    _LP_HOST_SYMBOL="%m"
-    _LP_FQDN_SYMBOL="%M"
     _LP_MARK_SYMBOL='%%'
 
     _LP_FIRST_INDEX=1
@@ -1242,21 +1238,22 @@ _lp_sudo_active_color() {
 _lp_hostname() {
     # Only process hostname elements if we haven't turned them off
     if (( LP_HOSTNAME_ALWAYS != -1 )); then
-
-        # Which host symbol should we use?
-        if (( LP_ENABLE_FQDN )); then
-            LP_HOST_SYMBOL="${_LP_FQDN_SYMBOL}"
-        else
-            LP_HOST_SYMBOL="${_LP_HOST_SYMBOL}"
-        fi
-
-        lp_hostname=${LP_HOST_SYMBOL}
-
         _lp_connection
         if [[ $lp_connection == lcl ]] && ! (( LP_HOSTNAME_ALWAYS )); then
             # no hostname if local
             return 1
         fi
+
+        lp_hostname=${HOSTNAME:-${HOST-}}
+
+        # Truncate to the first subdomain
+        if ! (( LP_ENABLE_FQDN )); then
+            lp_hostname=${lp_hostname%%.*}
+        fi
+
+        local ret
+        __lp_escape "$lp_hostname"
+        lp_hostname=$ret
     else
         return 2
     fi

--- a/liquidprompt
+++ b/liquidprompt
@@ -36,7 +36,6 @@ if test -n "${BASH_VERSION-}"; then
     _LP_OPEN_ESC="\["
     _LP_CLOSE_ESC="\]"
 
-    _LP_USER_SYMBOL="\u"
     _LP_HOST_SYMBOL="\h"
     _LP_FQDN_SYMBOL="\H"
     _LP_MARK_SYMBOL='$'
@@ -67,7 +66,6 @@ elif test -n "${ZSH_VERSION-}" ; then
     _LP_OPEN_ESC="%{"
     _LP_CLOSE_ESC="%}"
 
-    _LP_USER_SYMBOL="%n"
     _LP_HOST_SYMBOL="%m"
     _LP_FQDN_SYMBOL="%M"
     _LP_MARK_SYMBOL='%%'
@@ -1200,7 +1198,16 @@ _lp_username() {
         lp_username=''
         return 2
     elif (( LP_USER_ALWAYS )) || ! _lp_user; then
-        lp_username=${_LP_USER_SYMBOL}
+        lp_username=${USER:-${USERNAME:-${LOGNAME-}}}
+
+        if [[ -z $lp_username ]]; then
+            lp_username=$(id -nu 2>/dev/null)
+        fi
+
+        local ret
+        __lp_escape "$lp_username"
+        lp_username=$ret
+
         return 0
     else
         lp_username=''

--- a/liquidprompt
+++ b/liquidprompt
@@ -40,7 +40,6 @@ if test -n "${BASH_VERSION-}"; then
 
     _LP_FIRST_INDEX=0
     _LP_PERCENT='%'    # must be escaped on zsh
-    _LP_BACKSLASH='\\' # must be escaped on bash
 
     # Sed expression using extended regexp to match terminal
     # escape sequences with their wrappers
@@ -68,12 +67,11 @@ elif test -n "${ZSH_VERSION-}" ; then
 
     _LP_FIRST_INDEX=1
     _LP_PERCENT='%%'
-    _LP_BACKSLASH="\\"
 
     _LP_CLEAN_ESC='%\{([^%]+|%[^}])*%\}'
 
     __lp_escape() {
-        ret="${1//\%/$_LP_PERCENT}"
+        ret="${1//\%/%%}"
     }
 else
     echo "liquidprompt: shell not supported" >&2
@@ -502,8 +500,7 @@ lp_activate() {
     if _lp_multiplexer; then
         (( LP_ENABLE_TITLE = LP_ENABLE_TITLE && LP_ENABLE_SCREEN_TITLE ))
         LP_TITLE_OPEN=$'\Ek'
-        # "\e\" but on bash \ must be escaped
-        LP_TITLE_CLOSE=$'\E'"$_LP_BACKSLASH"
+        LP_TITLE_CLOSE=$'\E\\'
     else
         LP_TITLE_OPEN=$'\E]0;'
         LP_TITLE_CLOSE=$'\a'
@@ -891,18 +888,18 @@ _lp_path_format() {
 
     if [[ $path_length == 1 || $LP_PATH_METHOD == "truncate_to_last_dir" ]]; then
         if [[ $path_length > 1 ]]; then
-            __lp_escape "${display_path##*/}"
-            lp_path=$ret
+            lp_path=${display_path##*/}
         else
             # only root or home to show
-            __lp_escape "$display_path"
-            lp_path=$ret
+            lp_path=$display_path
         fi
 
+        __lp_escape "$lp_path"
+
         if [[ $display_path == $vcs_root_directory ]]; then
-            lp_path_format="${vcs_root_format}${lp_path}"
+            lp_path_format="${vcs_root_format}${ret}"
         else
-            lp_path_format="${last_directory_format}${lp_path}"
+            lp_path_format="${last_directory_format}${ret}"
         fi
         return
     else
@@ -943,14 +940,14 @@ _lp_path_format() {
         if [[ $current_path == $vcs_root_directory ]]; then
             __lp_end_path_left_shortening
             # No shortening
+            lp_path+=$current_directory
             __lp_escape "$current_directory"
-            lp_path+=$ret
             lp_path_format+="${vcs_root_format}${ret}"
         elif [[ -z $path_to_proccess ]]; then
             __lp_end_path_left_shortening
             # Last directory
+            lp_path+=$current_directory
             __lp_escape "$current_directory"
-            lp_path+=$ret
             lp_path_format+="${last_directory_format}${ret}"
         elif (( LP_ENABLE_SHORTEN_PATH && directory_count > LP_PATH_KEEP \
             && ( shortened_path_length > max_len || ( shortened_path_length >= max_len && is_shortening ) ) )); then
@@ -958,8 +955,8 @@ _lp_path_format() {
             if [[ $LP_PATH_METHOD == "truncate_chars_to_unique_dir" ]] && \
                 __lp_get_unique_directory "$current_path"; then
 
+                lp_path+=$lp_unique_directory
                 __lp_escape "$lp_unique_directory"
-                lp_path+=$ret
                 lp_path_format+="${shortened_directory_format}${ret}"
                 shortened_path_length=$(( shortened_path_length - ${#current_directory} + ${#lp_unique_directory} ))
             elif [[ $LP_PATH_METHOD == "truncate_chars_from_path_left" ]]; then
@@ -989,8 +986,8 @@ _lp_path_format() {
                     shortened_path_length=$(( shortened_path_length - needed_length ))
 
                     shortened_path="${LP_MARK_SHORTEN_PATH}${current_directory:$needed_length}"
+                    lp_path+=$shortened_path
                     __lp_escape "$shortened_path"
-                    lp_path+=$ret
                     lp_path_format+="${shortened_directory_format}${ret}"
 
                     is_shortening=0
@@ -999,29 +996,29 @@ _lp_path_format() {
                 (( ${#LP_MARK_SHORTEN_PATH} + LP_PATH_CHARACTER_KEEP < ${#current_directory} )); then
 
                 shortened_path="${current_directory:0:$LP_PATH_CHARACTER_KEEP}${LP_MARK_SHORTEN_PATH}"
+                lp_path+=$shortened_path
                 __lp_escape "$shortened_path"
-                lp_path+=$ret
                 lp_path_format+="${shortened_directory_format}${ret}"
                 shortened_path_length=$(( shortened_path_length - ${#current_directory} + ${#LP_MARK_SHORTEN_PATH} + LP_PATH_CHARACTER_KEEP ))
             elif [[ $LP_PATH_METHOD == "truncate_chars_from_dir_middle" ]] && \
                 (( ${#LP_MARK_SHORTEN_PATH} + LP_PATH_CHARACTER_KEEP * 2 < ${#current_directory} )); then
 
                 shortened_path="${current_directory:0:$LP_PATH_CHARACTER_KEEP}${LP_MARK_SHORTEN_PATH}${current_directory: -$LP_PATH_CHARACTER_KEEP}"
+                lp_path+=$shortened_path
                 __lp_escape "$shortened_path"
-                lp_path+=$ret
                 lp_path_format+="${shortened_directory_format}${ret}"
                 shortened_path_length=$(( shortened_path_length - ${#current_directory} + ${#LP_MARK_SHORTEN_PATH} + LP_PATH_CHARACTER_KEEP * 2 ))
             else
                 # Need to shorten, but no method matched, or the matched method
                 # did not make the string any shorter.
+                lp_path+=$current_directory
                 __lp_escape "$current_directory"
-                lp_path+=$ret
                 lp_path_format+="${path_format}${ret}"
             fi
         else
             __lp_end_path_left_shortening
+            lp_path+=$current_directory
             __lp_escape "$current_directory"
-            lp_path+=$ret
             lp_path_format+="${path_format}${ret}"
         fi
 
@@ -1206,22 +1203,20 @@ _lp_user() {
 _lp_username() {
     if (( LP_USER_ALWAYS == -1 )); then
         # No username ever
-        lp_username=''
         return 2
     elif (( LP_USER_ALWAYS )) || ! _lp_user; then
-        lp_username=${USER:-${USERNAME:-${LOGNAME-}}}
+        lp_username_raw=${USER:-${USERNAME:-${LOGNAME-}}}
 
-        if [[ -z $lp_username ]]; then
-            lp_username=$(id -nu 2>/dev/null)
+        if [[ -z $lp_username_raw ]]; then
+            lp_username_raw=$(id -nu 2>/dev/null)
         fi
 
         local ret
-        __lp_escape "$lp_username"
+        __lp_escape "$lp_username_raw"
         lp_username=$ret
 
         return 0
     else
-        lp_username=''
         return 1
     fi
 }
@@ -1259,15 +1254,15 @@ _lp_hostname() {
             return 1
         fi
 
-        lp_hostname=${HOSTNAME:-${HOST-}}
+        lp_hostname_raw=${HOSTNAME:-${HOST-}}
 
         # Truncate to the first subdomain
         if ! (( LP_ENABLE_FQDN )); then
-            lp_hostname=${lp_hostname%%.*}
+            lp_hostname_raw=${lp_hostname_raw%%.*}
         fi
 
         local ret
-        __lp_escape "$lp_hostname"
+        __lp_escape "$lp_hostname_raw"
         lp_hostname=$ret
     else
         return 2
@@ -2709,7 +2704,7 @@ _lp_default_theme_directory() {
         fi
     fi
 
-    local lp_path lp_path_format
+    local lp_path_format
     _lp_path_format "$LP_COLOR_PATH" "$LP_COLOR_PATH_LAST_DIR" "$LP_COLOR_PATH_VCS_ROOT" "$LP_COLOR_PATH_SHORTENED" "/" "$LP_COLOR_PATH_SEPARATOR"
 
     LP_PWD="${lp_path_format}${NO_COL}"
@@ -2830,8 +2825,8 @@ _lp_default_theme_prompt_template() {
         # add return code and prompt mark
         PS1+="${LP_RUNTIME}${LP_ERR}${LP_MARK_PREFIX}${LP_COLOR_MARK}${LP_MARK}${LP_PS1_POSTFIX}"
 
-        # Get the current prompt on the fly and make it a title
-        _lp_formatted_title "$PS1"
+        # Get the core sections without prompt escapes and make them into a title.
+        _lp_formatted_title "${LP_PS1_PREFIX}${LP_MARK_BRACKET_OPEN}${lp_username_raw-}${lp_hostname_raw+@}${lp_hostname_raw-}${LP_MARK_PERM}${lp_path-}${LP_MARK_BRACKET_CLOSE}${LP_MARK_PREFIX}${lp_smart_mark} ${LP_PS1_POSTFIX}"
 
         # Glue the bash prompt always go to the first column.
         # Avoid glitches after interrupting a command with Ctrl-C

--- a/liquidprompt
+++ b/liquidprompt
@@ -870,6 +870,8 @@ _lp_path_format() {
     lp_path=
     lp_path_format=
 
+    local ret
+
     local lp_pwd_tilde
     __lp_pwd_tilde
     local display_path=$lp_pwd_tilde
@@ -885,10 +887,12 @@ _lp_path_format() {
 
     if [[ $path_length == 1 || $LP_PATH_METHOD == "truncate_to_last_dir" ]]; then
         if [[ $path_length > 1 ]]; then
-            lp_path=${display_path##*/}
+            __lp_escape "${display_path##*/}"
+            lp_path=$ret
         else
             # only root or home to show
-            lp_path=$display_path
+            __lp_escape "$display_path"
+            lp_path=$ret
         fi
 
         if [[ $display_path == $vcs_root_directory ]]; then
@@ -935,21 +939,24 @@ _lp_path_format() {
         if [[ $current_path == $vcs_root_directory ]]; then
             __lp_end_path_left_shortening
             # No shortening
-            lp_path+=$current_directory
-            lp_path_format+="${vcs_root_format}${current_directory}"
+            __lp_escape "$current_directory"
+            lp_path+=$ret
+            lp_path_format+="${vcs_root_format}${ret}"
         elif [[ -z $path_to_proccess ]]; then
             __lp_end_path_left_shortening
             # Last directory
-            lp_path+=$current_directory
-            lp_path_format+="${last_directory_format}${current_directory}"
+            __lp_escape "$current_directory"
+            lp_path+=$ret
+            lp_path_format+="${last_directory_format}${ret}"
         elif (( LP_ENABLE_SHORTEN_PATH && directory_count > LP_PATH_KEEP \
             && ( shortened_path_length > max_len || ( shortened_path_length >= max_len && is_shortening ) ) )); then
 
             if [[ $LP_PATH_METHOD == "truncate_chars_to_unique_dir" ]] && \
                 __lp_get_unique_directory "$current_path"; then
 
-                lp_path+=$lp_unique_directory
-                lp_path_format+="${shortened_directory_format}${lp_unique_directory}"
+                __lp_escape "$lp_unique_directory"
+                lp_path+=$ret
+                lp_path_format+="${shortened_directory_format}${ret}"
                 shortened_path_length=$(( shortened_path_length - ${#current_directory} + ${#lp_unique_directory} ))
             elif [[ $LP_PATH_METHOD == "truncate_chars_from_path_left" ]]; then
                 # The only way to know if this consecutive directory shortening
@@ -978,8 +985,9 @@ _lp_path_format() {
                     shortened_path_length=$(( shortened_path_length - needed_length ))
 
                     shortened_path="${LP_MARK_SHORTEN_PATH}${current_directory:$needed_length}"
-                    lp_path+=$shortened_path
-                    lp_path_format+="${shortened_directory_format}${shortened_path}"
+                    __lp_escape "$shortened_path"
+                    lp_path+=$ret
+                    lp_path_format+="${shortened_directory_format}${ret}"
 
                     is_shortening=0
                 fi
@@ -987,26 +995,30 @@ _lp_path_format() {
                 (( ${#LP_MARK_SHORTEN_PATH} + LP_PATH_CHARACTER_KEEP < ${#current_directory} )); then
 
                 shortened_path="${current_directory:0:$LP_PATH_CHARACTER_KEEP}${LP_MARK_SHORTEN_PATH}"
-                lp_path+=$shortened_path
-                lp_path_format+="${shortened_directory_format}${shortened_path}"
+                __lp_escape "$shortened_path"
+                lp_path+=$ret
+                lp_path_format+="${shortened_directory_format}${ret}"
                 shortened_path_length=$(( shortened_path_length - ${#current_directory} + ${#LP_MARK_SHORTEN_PATH} + LP_PATH_CHARACTER_KEEP ))
             elif [[ $LP_PATH_METHOD == "truncate_chars_from_dir_middle" ]] && \
                 (( ${#LP_MARK_SHORTEN_PATH} + LP_PATH_CHARACTER_KEEP * 2 < ${#current_directory} )); then
 
                 shortened_path="${current_directory:0:$LP_PATH_CHARACTER_KEEP}${LP_MARK_SHORTEN_PATH}${current_directory: -$LP_PATH_CHARACTER_KEEP}"
-                lp_path+=$shortened_path
-                lp_path_format+="${shortened_directory_format}${shortened_path}"
+                __lp_escape "$shortened_path"
+                lp_path+=$ret
+                lp_path_format+="${shortened_directory_format}${ret}"
                 shortened_path_length=$(( shortened_path_length - ${#current_directory} + ${#LP_MARK_SHORTEN_PATH} + LP_PATH_CHARACTER_KEEP * 2 ))
             else
                 # Need to shorten, but no method matched, or the matched method
                 # did not make the string any shorter.
-                lp_path+=$current_directory
-                lp_path_format+="${path_format}${current_directory}"
+                __lp_escape "$current_directory"
+                lp_path+=$ret
+                lp_path_format+="${path_format}${ret}"
             fi
         else
             __lp_end_path_left_shortening
-            lp_path+=$current_directory
-            lp_path_format+="${path_format}${current_directory}"
+            __lp_escape "$current_directory"
+            lp_path+=$ret
+            lp_path_format+="${path_format}${ret}"
         fi
 
         if [[ -n $path_to_proccess && ( $current_path != "/" || $separator != "/" ) ]] && (( ! is_shortening )); then

--- a/tests/test_utils.sh
+++ b/tests/test_utils.sh
@@ -314,10 +314,10 @@ function test_path_format_from_path_left() {
   LP_PATH_LENGTH=${#PWD}
   _lp_path_format ''
   if (( _LP_SHELL_zsh )); then
-    assertEquals "shell escapes" $'/a_fake_\\n_newline/and_%%100_fresh/and_a_real_\n_newline' "$lp_path"
+    assertEquals "shell escapes" $'/a_fake_\\n_newline/and_%100_fresh/and_a_real_\n_newline' "$lp_path"
     assertEquals "shell escapes format" $'/a_fake_\\n_newline/and_%%100_fresh/and_a_real_\n_newline' "$lp_path_format"
   else
-    assertEquals "shell escapes" $'/a_fake_\\\\n_newline/and_%100_fresh/and_a_real_\n_newline' "$lp_path"
+    assertEquals "shell escapes" $'/a_fake_\\n_newline/and_%100_fresh/and_a_real_\n_newline' "$lp_path"
     assertEquals "shell escapes format" $'/a_fake_\\\\n_newline/and_%100_fresh/and_a_real_\n_newline' "$lp_path_format"
   fi
 }

--- a/tests/test_utils.sh
+++ b/tests/test_utils.sh
@@ -275,6 +275,17 @@ function test_path_format_from_path_left() {
   LP_PATH_LENGTH=$(( ${#PWD} - 1 ))
   _lp_path_format ''
   assertEquals "no shortening" "/tmp/a/b/c/last" "$lp_path_format"
+
+  PWD=$'/a_fake_\\n_newline/and_%100_fresh/and_a_real_\n_newline'
+  LP_PATH_LENGTH=${#PWD}
+  _lp_path_format ''
+  if (( _LP_SHELL_zsh )); then
+    assertEquals "shell escapes" $'/a_fake_\\n_newline/and_%%100_fresh/and_a_real_\n_newline' "$lp_path"
+    assertEquals "shell escapes format" $'/a_fake_\\n_newline/and_%%100_fresh/and_a_real_\n_newline' "$lp_path_format"
+  else
+    assertEquals "shell escapes" $'/a_fake_\\\\n_newline/and_%100_fresh/and_a_real_\n_newline' "$lp_path"
+    assertEquals "shell escapes format" $'/a_fake_\\\\n_newline/and_%100_fresh/and_a_real_\n_newline' "$lp_path_format"
+  fi
 }
 
 function test_path_format_from_dir_right {

--- a/tests/test_utils.sh
+++ b/tests/test_utils.sh
@@ -91,6 +91,40 @@ function test_floating_scale {
   assertEquals "scaling 10" '123' "$ret"
 }
 
+function test_get_last_command_line() {
+  if (( _LP_SHELL_zsh )); then
+    # This is simpler, and only shows one test as skipped instead of per assert.
+    startSkipping
+    assertTrue ''
+    endSkipping
+    return
+  fi
+
+  builtin() {
+    printf '%s\n' "$history_line"
+  }
+
+  local command
+
+  history_line=' 100  command'
+  __lp_get_last_command_line
+  assertEquals "normal history" 'command' "$command"
+
+  history_line='1000  a command'
+  __lp_get_last_command_line
+  assertEquals "no leading space" 'a command' "$command"
+
+  history_line='    0  a different command'
+  __lp_get_last_command_line
+  assertEquals "single digit index" 'a different command' "$command"
+
+  history_line='  119* a modified command'
+  __lp_get_last_command_line
+  assertEquals "modified history" 'a modified command' "$command"
+
+  unset -f builtin
+}
+
 function test_pwd_tilde {
   typeset HOME="/home/user"
   typeset PWD="/a/test/path"

--- a/themes/powerline/powerline.theme
+++ b/themes/powerline/powerline.theme
@@ -53,12 +53,8 @@ __powerline_username_generate() {
 _lp_powerline_theme_directory() {
     # Not all terminals support Powerline special characters in the title
     local title=
-    if [[ -n $_POWERLINE_USERNAME ]]; then
-        title+=${_POWERLINE_USERNAME}
-    fi
-    if [[ -n $_POWERLINE_HOSTNAME ]]; then
-        title+="@${_POWERLINE_HOSTNAME}"
-    fi
+    title+=${lp_username_raw-}
+    title+="${lp_hostname_raw+@}${lp_hostname_raw-}"
 
     local lp_path
     __powerline_path_generate
@@ -66,7 +62,8 @@ _lp_powerline_theme_directory() {
     [[ -n $title ]] && title+=":"
     title+="${lp_path}"
 
-    _lp_raw_title "$title"
+    # Include a trailing space to pad for the title command.
+    _lp_raw_title "$title "
 }
 
 _lp_powerline_theme_prompt() {


### PR DESCRIPTION
Replace all data sources that use prompt escape codes with actual data. This is prompt mark, digital date, username, and hostname.

Remove backslash escaping from Zsh __lp_escape(). This was added in commit 74e14fe. I don't understand why, except that maybe a single backslash display would look like an escape code for a control character, like `\n`. But that is not the case for Bash, so why the difference?

Zsh only uses percents (%) to escape things in the prompt, where Bash only uses bashslashes. This changes makes the same input string print the same way in the prompt for both shells.

Add Title command feature. This needed to rework how the runtime feature was handled, since it monopolized the DEBUG trap in Bash. Now it can handle multiple features that need to run after the user has submitted the command, but before it runs.

The feature itself is simple: lookup the latest command in the history, and print the normal title postpended by that command to the screen, formatted as a terminal title. Note that Bash's `$BASH_COMMAND` is not great, as it only contains the current _command_, not the whole command line.

Add raw string passing to fix title issues. The problem is simple enough: the extra backslashes or percents that __lp_escape() adds show up in the title, as the title is changed in the previous commit to no longer be printed as part of PS1. Add a "raw" copy of the data strings for username, hostname, and current path with no color or shell character escaping. This is designed for putting into the terminal title, but it could also be used for comparisons. lp_path_format() already had a no formatting return var in lp_path, but now it is not shell escaped.

The title is changed from duplicating the prompt to instead showing just the core bits in the central brackets: username, hostname, current path, followed by the prompt mark. As well as the user prefix, postfix, and MARK_PREFIX. This is a change from the long standing default, but it is customizable both by themes and users, and I have long seen complaints of the current title layout being less than helpful.

Resolves #651, resolves #609, resolves #281