### PR TITLE
Fix `_lp_git_bookmark()` cmd not found msgs (brewed bash, macOS x86)

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -1522,10 +1522,10 @@ _lp_vcs_details_color() {
     if _lp_vcs_branch; then
         branch="$lp_vcs_branch"
 
-        if _lp_vcs_bookmark; then
+        if _lp_vcs_bookmark > /dev/null; then
             branch+=": $lp_vcs_bookmark"
         fi
-    elif _lp_vcs_bookmark; then
+    elif _lp_vcs_bookmark > /dev/null; then
         branch="$lp_vcs_bookmark"
     elif _lp_vcs_tag; then
         branch="tag: $lp_vcs_tag"


### PR DESCRIPTION
On macOS (10.15.7, x86) with brewed Bash (5.1.4(1)-release) and certain
Bash options set, command not found error messages are printed when
`_lp_vcs_bookmark()` is invoked as the TEST-COMMAND of an if statement.
This is rather annoying. The output is printed on stdout. This commit
fixes the issue by discarding any output created by the if TEST-COMMAND.

Here are my Bash settings for completeness & reproducibility:
```
$ set -o
allexport       off
braceexpand     on
emacs           on
errexit         off
errtrace        on
functrace       off
hashall         on
histexpand      on
history         on
ignoreeof       off
interactive-comments    on
keyword         off
monitor         on
noclobber       off
noexec          off
noglob          off
nolog           off
notify          off
nounset         off
onecmd          off
physical        off
pipefail        off
posix           off
privileged      off
verbose         off
vi              off
xtrace          off
```

Screenshot of the issue on master branch (as of 145f146e9cb4fb3c30a22e6c35529120f4650a28):

![image](https://user-images.githubusercontent.com/279612/114771188-466acb00-9d3a-11eb-9c82-1845157a928a.png)

Screenshot showing issue is now resolved in this PR:

![image](https://user-images.githubusercontent.com/279612/114771402-80d46800-9d3a-11eb-9d1e-6f034ccc1ae2.png)
