### PR TITLE
Add hyperlinks for directories in path

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -515,6 +515,49 @@ Features
 
    See also: :attr:`LP_MARK_HG` and :attr:`LP_HG_COMMAND`.
 
+.. attribute:: LP_ENABLE_HYPERLINKS
+   :type: bool
+   :value: 0
+
+   Adds clickable links to some elements of the prompt:
+
+   - If locally connected, adds a link to
+     each displayed elements of the path, using the ``file://`` scheme.
+   - Within remote SSH connections, adds a link to
+     each element of the path, but using the ``sftp://`` protocol,
+     configured with the *current* username and hostname.
+   - If the hostname is displayed within an SSH connection,
+     adds a ``ssh://`` URL to it.
+
+   The links take the form of a OSC-8 escape sequences
+   containing an Uniform Resource Locator,
+   which should be interpreted by the terminal emulator.
+   If your terminal emulator does not support OSC-8,
+   it may display escapement garbage.
+   As not all terminal emulator support links,
+   this feature is disabled by default.
+
+   .. warning:: Your system should be configured to handle
+                the aforementioned link schemes.
+                If nothing happen when you click on the link,
+                or if the wrong application is used,
+                there is a configuration problem on your system
+                or with your terminal emulator
+                (not with Liquid Prompt).
+
+   .. note:: Liquid Prompt cannot possibly follow complex remote connections.
+             Remote links are thus configured with the *current* username,
+             and the *current* fully qualified domain name,
+             as ``sftp://<username>@<hostname>/<path>``.
+             It is possible that this URL does not work the same way
+             than a manual connection.
+             For instance, if you proxy jumped
+             (i.e. if you jumped from one connection to the other),
+             and/or you logged in with another user, and/or used SSH aliases,
+             then the links probably won't work the way you may expect.
+
+   .. versionadded:: 2.2
+
 .. attribute:: LP_ENABLE_JOBS
    :type: bool
    :value: 1

--- a/docs/functions/util.rst
+++ b/docs/functions/util.rst
@@ -26,6 +26,22 @@ These functions are designed to be used by themes.
 
    The returned string is a fully escaped terminal formatting sequence.
 
+.. function:: _lp_create_link(url, text) -> var:lp_link
+
+   Adds the *url* link to the given *text*.
+
+   See :attr:`LP_ENABLE_HYPERLINKS`.
+
+.. function:: _lp_create_link_path(path) -> lp_link_path
+
+   Adds a link on the given path, with the protocol scheme
+   depending on the current connection type.
+
+   If the current connection is *SSH*, adds an ``SFTP://`` URL,
+   if it is *su* or *lcl* (see :func:`_lp_connection`), adds a ``file://`` one.
+
+   See also :attr:`LP_ENABLE_HYPERLINKS` and :func:`_lp_create_link`.
+
 .. function:: _lp_fill(left, right, [fillstring], [splitends]) -> var:lp_fill
 
    Adds as much *fillstring* (e.g. spaces) between *left* and *right*,

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -168,6 +168,7 @@ Miscellaneous:
 - :attr:`LP_ENABLE_TITLE` (may behave inconsistently on exotic terminals)
 - :attr:`LP_ENABLE_SCREEN_TITLE`
 - :attr:`LP_ENABLE_WIFI_STRENGTH` (Linux or MacOS)
+- :attr:`LP_ENABLE_HYPERLINKS` (not supported by all terminal emulators)
 
 Disabled by default for security:
 

--- a/liquidprompt
+++ b/liquidprompt
@@ -954,11 +954,34 @@ _lp_color_map() {
 # Generate a terminal hyperlink from a URL and text.
 _lp_create_link() {  # url, text
     (( LP_ENABLE_HYPERLINKS )) || return 2
+    lp_link="$_LP_OPEN_ESC"$'\E]8;;'"${1}"$'\E'"${_LP_BACKSLASH}${_LP_CLOSE_ESC}${2}${_LP_OPEN_ESC}"$'\E]8;;\E'"${_LP_BACKSLASH}$_LP_CLOSE_ESC"
+}
 
-    local ret
-    __lp_escape "$1"
+# Add a link to a path element, with protocol depending on the connection.
+_lp_create_link_path() { # path
+    local path="$1"
+    if (( LP_ENABLE_HYPERLINKS )); then
+        _lp_connection
 
-    link="$_LP_OPEN_ESC"$'\E]8;;'"${1}"$'\E'"${_LP_BACKSLASH}${_LP_CLOSE_ESC}${2}${_LP_OPEN_ESC}"$'\E]8;;\E'"${_LP_BACKSLASH}$_LP_CLOSE_ESC"
+        if [[ "$lp_connection" == "ssh" ]]; then
+            # SSH connection needs the `sftp` protocol to reach the remote host.
+            local client_ip client_port server_ip server_port
+            IFS=" " read -r client_ip client_port server_ip server_port <<<"$SSH_CONNECTION"
+            local username=${USER:-${USERNAME:-${LOGNAME-}}}
+            _lp_create_link "sftp://${username}@${server_ip}:${client_port}/${PWD}/" "$path"
+            lp_link_path="$lp_link"
+
+        elif [[ "$lp_connection" == "su" || "$lp_connection" == "lcl" ]]; then
+            # Reach local host with the `file` protocol.
+            _lp_create_link "file://${PWD}/" "$path"
+            lp_link_path="$lp_link"
+
+        else # no link for telnet.
+            lp_link_path="$path"
+        fi
+    else # No link.
+        lp_link_path="$path"
+    fi
 }
 
 # Return true if the input is the name of a function.
@@ -1351,7 +1374,7 @@ _lp_path_format() {
     lp_path=
     lp_path_format=
 
-    local ret link
+    local ret lp_link_path
 
     local lp_pwd_tilde
     __lp_pwd_tilde
@@ -1377,15 +1400,11 @@ _lp_path_format() {
         __lp_escape "$lp_path"
 
         if [[ $display_path == "$vcs_root_directory" ]]; then
-            lp_path_format="${vcs_root_format}${ret}"
+            _lp_create_link_path "${ret}"
+            lp_path_format="${vcs_root_format}$lp_link_path"
         else
-            lp_path_format="${last_directory_format}"
-        fi
-
-        if _lp_create_link "file://${PWD}/" "$ret"; then
-            lp_path_format+=$link
-        else
-            lp_path_format+=$ret
+            _lp_create_link_path "${ret}"
+            lp_path_format="${last_directory_format}$lp_link_path"
         fi
 
         return
@@ -1510,11 +1529,9 @@ _lp_path_format() {
         fi
 
         if (( ! is_shortening )); then
-            if _lp_create_link "file://${current_path/#"~/"/"$HOME/"}/" "$ret"; then
-                lp_path_format+=$link
-            else
-                lp_path_format+=$ret
-            fi
+
+            _lp_create_link_path "$ret"
+            lp_path_format+="$lp_link_path"
 
             if [[ -n $path_to_proccess && ( $current_path != "/" || $separator != "/" ) ]]; then
                 if [[ $current_path != "/" ]]; then
@@ -2219,6 +2236,7 @@ _lp_hostname() {
         local ret
         __lp_escape "$lp_hostname"
         lp_hostname=$ret
+
     else
         return 2
     fi
@@ -2239,14 +2257,25 @@ _lp_hostname_color() {
     fi
 
     if _lp_hostname; then
+
         case "$lp_connection" in
         lcl)
             lp_hostname_color+="@${LP_COLOR_HOST}${lp_hostname}${NO_COL}"
             ;;
         ssh)
+            local client_ip client_port server_ip server_port hostname=
+            # client_* are unused
+            # shellcheck disable=SC2034
+            IFS=" " read -r client_ip client_port server_ip server_port <<<"$SSH_CONNECTION"
+            local username=${USER:-${USERNAME:-${LOGNAME-}}}
+            if _lp_create_link "ssh://${username}@${server_ip}:${server_port}" "$lp_hostname"; then
+                hostname="$lp_link"
+            else
+                hostname="$lp_hostname"
+            fi
             # If we want a different color for each host
             (( LP_ENABLE_SSH_COLORS )) && LP_COLOR_SSH="$LP_COLOR_HOST_HASH"
-            lp_hostname_color+="@${LP_COLOR_SSH}${lp_hostname}${NO_COL}"
+            lp_hostname_color+="@${LP_COLOR_SSH}${hostname}${NO_COL}"
             ;;
         su)
             lp_hostname_color+="@${LP_COLOR_SU}${lp_hostname}${NO_COL}"

--- a/liquidprompt
+++ b/liquidprompt
@@ -43,6 +43,7 @@ if test -n "${BASH_VERSION-}"; then
 
     _LP_FIRST_INDEX=0
     _LP_PERCENT='%'    # must be escaped on zsh
+    _LP_BACKSLASH='\\' # must be escaped on bash
 
     # Escape the given strings
     # Must be used for all strings injected in PS1 that may comes from remote sources,
@@ -89,6 +90,7 @@ elif test -n "${ZSH_VERSION-}" ; then
 
     _LP_FIRST_INDEX=1
     _LP_PERCENT='%%'
+    _LP_BACKSLASH='\'
 
     __lp_escape() {
         ret="${1//\\/\\\\}"
@@ -456,6 +458,7 @@ __lp_source_config() {
     LP_ENABLE_OS_KERNEL=${LP_ENABLE_OS_KERNEL:-1}
     LP_ENABLE_OS_DISTRIB=${LP_ENABLE_OS_DISTRIB:-0}
     LP_ENABLE_OS_VERSION=${LP_ENABLE_OS_VERSION:-1}
+    LP_ENABLE_HYPERLINKS=${LP_ENABLE_HYPERLINKS:-0}
 
     LP_MARK_DEFAULT="${LP_MARK_DEFAULT:-$_LP_MARK_SYMBOL}"
     LP_MARK_BATTERY="${LP_MARK_BATTERY:-"⌁"}"
@@ -948,6 +951,16 @@ _lp_color_map() {
     ret="${LP_COLORMAP[_LP_FIRST_INDEX+value*${#LP_COLORMAP[*]}/scale]}"
 }
 
+# Generate a terminal hyperlink from a URL and text.
+_lp_create_link() {  # url, text
+    (( LP_ENABLE_HYPERLINKS )) || return 2
+
+    local ret
+    __lp_escape "$1"
+
+    link="$_LP_OPEN_ESC"$'\E]8;;'"${1}"$'\E'"${_LP_BACKSLASH}${_LP_CLOSE_ESC}${2}${_LP_OPEN_ESC}"$'\E]8;;\E'"${_LP_BACKSLASH}$_LP_CLOSE_ESC"
+}
+
 # Return true if the input is the name of a function.
 __lp_is_function() {
     if (( _LP_SHELL_bash )); then
@@ -1338,7 +1351,7 @@ _lp_path_format() {
     lp_path=
     lp_path_format=
 
-    local ret
+    local ret link
 
     local lp_pwd_tilde
     __lp_pwd_tilde
@@ -1366,8 +1379,15 @@ _lp_path_format() {
         if [[ $display_path == "$vcs_root_directory" ]]; then
             lp_path_format="${vcs_root_format}${ret}"
         else
-            lp_path_format="${last_directory_format}${ret}"
+            lp_path_format="${last_directory_format}"
         fi
+
+        if _lp_create_link "file://${PWD}/" "$ret"; then
+            lp_path_format+=$link
+        else
+            lp_path_format+=$ret
+        fi
+
         return
     else
         if [[ $separator != "/" && ${display_path:0:1} == "/" ]]; then
@@ -1409,13 +1429,13 @@ _lp_path_format() {
             # No shortening
             lp_path+=$current_directory
             __lp_escape "$current_directory"
-            lp_path_format+="${vcs_root_format}${ret}"
+            lp_path_format+="${vcs_root_format}"
         elif [[ -z $path_to_proccess ]]; then
             __lp_end_path_left_shortening
             # Last directory
             lp_path+=$current_directory
             __lp_escape "$current_directory"
-            lp_path_format+="${last_directory_format}${ret}"
+            lp_path_format+="${last_directory_format}"
         elif (( LP_ENABLE_SHORTEN_PATH && directory_count > LP_PATH_KEEP \
             && ( shortened_path_length > max_len || ( shortened_path_length >= max_len && is_shortening ) ) )); then
 
@@ -1424,7 +1444,7 @@ _lp_path_format() {
 
                 lp_path+=$lp_unique_directory
                 __lp_escape "$lp_unique_directory"
-                lp_path_format+="${shortened_directory_format}${ret}"
+                lp_path_format+="${shortened_directory_format}"
                 shortened_path_length=$(( shortened_path_length - ${#current_directory} + ${#lp_unique_directory} ))
             elif [[ $LP_PATH_METHOD == "truncate_chars_from_path_left" ]]; then
                 # The only way to know if this consecutive directory shortening
@@ -1455,7 +1475,7 @@ _lp_path_format() {
                     shortened_path="${LP_MARK_SHORTEN_PATH}${current_directory:$needed_length}"
                     lp_path+=$shortened_path
                     __lp_escape "$shortened_path"
-                    lp_path_format+="${shortened_directory_format}${ret}"
+                    lp_path_format+="${shortened_directory_format}"
 
                     is_shortening=0
                 fi
@@ -1465,7 +1485,7 @@ _lp_path_format() {
                 shortened_path="${current_directory:0:$LP_PATH_CHARACTER_KEEP}${LP_MARK_SHORTEN_PATH}"
                 lp_path+=$shortened_path
                 __lp_escape "$shortened_path"
-                lp_path_format+="${shortened_directory_format}${ret}"
+                lp_path_format+="${shortened_directory_format}"
                 shortened_path_length=$(( shortened_path_length - ${#current_directory} + ${#LP_MARK_SHORTEN_PATH} + LP_PATH_CHARACTER_KEEP ))
             elif [[ $LP_PATH_METHOD == "truncate_chars_from_dir_middle" ]] && \
                 (( ${#LP_MARK_SHORTEN_PATH} + LP_PATH_CHARACTER_KEEP * 2 < ${#current_directory} )); then
@@ -1473,27 +1493,35 @@ _lp_path_format() {
                 shortened_path="${current_directory:0:$LP_PATH_CHARACTER_KEEP}${LP_MARK_SHORTEN_PATH}${current_directory: -$LP_PATH_CHARACTER_KEEP}"
                 lp_path+=$shortened_path
                 __lp_escape "$shortened_path"
-                lp_path_format+="${shortened_directory_format}${ret}"
+                lp_path_format+="${shortened_directory_format}"
                 shortened_path_length=$(( shortened_path_length - ${#current_directory} + ${#LP_MARK_SHORTEN_PATH} + LP_PATH_CHARACTER_KEEP * 2 ))
             else
                 # Need to shorten, but no method matched, or the matched method
                 # did not make the string any shorter.
                 lp_path+=$current_directory
                 __lp_escape "$current_directory"
-                lp_path_format+="${path_format}${ret}"
+                lp_path_format+="${path_format}"
             fi
         else
             __lp_end_path_left_shortening
             lp_path+=$current_directory
             __lp_escape "$current_directory"
-            lp_path_format+="${path_format}${ret}"
+            lp_path_format+="${path_format}"
         fi
 
-        if [[ -n $path_to_proccess && ( $current_path != "/" || $separator != "/" ) ]] && (( ! is_shortening )); then
-            if [[ $current_path != "/" ]]; then
-                lp_path+="/"
+        if (( ! is_shortening )); then
+            if _lp_create_link "file://${current_path/#"~/"/"$HOME/"}/" "$ret"; then
+                lp_path_format+=$link
+            else
+                lp_path_format+=$ret
             fi
-            lp_path_format+="${separator_format}${separator}"
+
+            if [[ -n $path_to_proccess && ( $current_path != "/" || $separator != "/" ) ]]; then
+                if [[ $current_path != "/" ]]; then
+                    lp_path+="/"
+                fi
+                lp_path_format+="${separator_format}${separator}"
+            fi
         fi
     done
 }

--- a/tests/test_acpi.sh
+++ b/tests/test_acpi.sh
@@ -92,7 +92,7 @@ function test_acpi_temperature {
   # Stub needed to test acpi with no output.
   sensors() { :; }
 
-  local valid
+  typeset valid
 
   for (( index=0; index < ${#temp_values[@]}; index++ )); do
     __temp_output=${temp_outputs[$index]}

--- a/tests/test_connection.sh
+++ b/tests/test_connection.sh
@@ -98,7 +98,7 @@ values+=(lcl)
 
 
 function test_connection {
-  local SSH_CLIENT REMOTEHOST SSH2_CLIENT="" SSH_TTY=""
+  typeset SSH_CLIENT REMOTEHOST SSH2_CLIENT="" SSH_TTY=""
 
   ps() {
     printf '%s\n' "$__ps_output"

--- a/tests/test_sysfs.sh
+++ b/tests/test_sysfs.sh
@@ -60,7 +60,7 @@ test_sysfs_battery() {
   _LP_LINUX_POWERSUPPLY_PATH="$SHUNIT_TMPDIR"
 
   for (( index=0; index < ${#battery_values[@]}; index++ )); do
-    local power_supply="${_LP_LINUX_POWERSUPPLY_PATH}/${index}"
+    typeset power_supply="${_LP_LINUX_POWERSUPPLY_PATH}/${index}"
     mkdir "$power_supply"
 
     if [[ -n ${battery_types[index]-} ]]; then
@@ -104,7 +104,7 @@ test_sysfs_temperature() {
     "${SHUNIT_TMPDIR}/hwmon2_temp1_input"
     "${SHUNIT_TMPDIR}/thermal_zone0_temp"
   )
-  local -i i=0
+  typeset -i i=0
   printf '%s\n' 27000 > "${_LP_LINUX_TEMPERATURE_FILES[i++]}"
   printf '%s\n' 12000 > "${_LP_LINUX_TEMPERATURE_FILES[i++]}"
   printf '%s\n' 17000 > "${_LP_LINUX_TEMPERATURE_FILES[i++]}"

--- a/tests/test_tools.sh
+++ b/tests/test_tools.sh
@@ -3,6 +3,7 @@
 set -u
 
 LP_ROOT="${PWD%/tests}"
+SSH_CONNECTION="1.2.3.4 111 5.6.7.8 222"
 
 function setUp {
   cd "$LP_ROOT"

--- a/tests/test_utils.sh
+++ b/tests/test_utils.sh
@@ -191,6 +191,7 @@ function test_path_format_from_path_left() {
   }
 
   LP_ENABLE_SHORTEN_PATH=1
+  LP_ENABLE_HYPERLINKS=0
   typeset COLUMNS=100
   LP_PATH_LENGTH=100
   LP_PATH_KEEP=0
@@ -339,6 +340,7 @@ function test_path_format_from_dir_right {
   }
 
   LP_ENABLE_SHORTEN_PATH=1
+  LP_ENABLE_HYPERLINKS=0
   typeset COLUMNS=100
   LP_PATH_LENGTH=100
   LP_PATH_KEEP=0
@@ -433,6 +435,7 @@ function test_path_format_from_dir_middle {
   }
 
   LP_ENABLE_SHORTEN_PATH=1
+  LP_ENABLE_HYPERLINKS=0
   typeset COLUMNS=100
   LP_PATH_LENGTH=100
   LP_PATH_KEEP=0
@@ -537,6 +540,7 @@ function test_path_format_unique() {
   }
 
   LP_ENABLE_SHORTEN_PATH=1
+  LP_ENABLE_HYPERLINKS=0
   typeset COLUMNS=100
   LP_PATH_LENGTH=100
   LP_PATH_KEEP=0
@@ -629,6 +633,7 @@ function test_path_format_last_dir() {
   }
 
   LP_ENABLE_SHORTEN_PATH=1
+  LP_ENABLE_HYPERLINKS=0
   LP_PATH_VCS_ROOT=1
   LP_PATH_METHOD=truncate_to_last_dir
 


### PR DESCRIPTION
Add a _lp_create_link() function that turns a URL and text into a operating system command sequence for a clickable hyperlink in the
terminal. See https://github.com/mintty/mintty/wiki/CtrlSeqs#hyperlinks for details.

Add sections of the current path as hyperlinks, with the "file://" protocol.

Remaining questions:

- [ ] Should links be added for other objects in the prompt? I can't think of any good ideas, other than VCS branches linking to the remote site copy of the branch. Or maybe, since Python virtualenvs IDs are nothing more than their path, they could be done the same as the path sections.
- [ ] Should there be `ENABLE` config options for each type of link?
- [ ] Should it be enabled or disabled by default?
- [ ] Should it be scoped to controlled by themes, or by Liquidprompt internals? (this current implementation uses it only in internals, not at the default theme level)
- [ ] Needs docs written.
- [ ] Needs specific test coverage.

Resolves #659