### PR TITLE
Add LP_KUBECONTEXT_DELIMITER_STRIP_PREFIX

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -188,24 +188,52 @@ General
 Features
 --------
 
-.. attribute:: LP_DELIMITER_KUBECONTEXT
+.. attribute:: LP_DELIMITER_KUBECONTEXT_PREFIX
    :type: string
    :value: ""
 
-   Delimiter to shorten the Kubernetes context.
+   Delimiter to shorten the Kubernetes context by removing a prefix.
+
+   Usage example:
+
+   * if your context names are cluster-dev and cluster-test,
+     then set this to "-" in order to output "dev" and "test" in prompt.
+   * if using AWS EKS then set this to '/' to show only the cluster name,
+     without the rest of the ARN
+     (arn:aws:eks:$AWS_REGION:$ACCOUNT_ID:cluster/$CLUSTER_NAME)
+   * alternatively, if using AWS EKS, set this to ':' to show only
+     "cluster/$CLUSTER_NAME".  (Note: the prefix removed is a greedy match - it
+     contains all the ":"s in the input.)
+
+   If set to the empty string no truncating will occur (this is the default).
+
+   See also: :attr:`LP_ENABLE_KUBECONTEXT`,
+   :attr:`LP_DELIMITER_KUBECONTEXT_SUFFIX`, :attr:`LP_COLOR_KUBECONTEXT`,
+   and :attr:`LP_MARK_KUBECONTEXT`.
+
+   .. versionadded:: 2.1
+
+.. attribute:: LP_DELIMITER_KUBECONTEXT_SUFFIX
+   :type: string
+   :value: ""
+
+   Delimiter to shorten the Kubernetes context by removing a suffix.
 
    Usage example:
 
    * if your context names are dev-cluster and test-cluster,
      then set this to "-" in order to output "dev" and "test" in prompt.
    * if your context names are dev.k8s.example.com and test.k8s.example.com,
-     then set this to "." in order to output "dev" and "test" in prompt.
+     then set this to "." in order to output "dev" and "test" in prompt. (Note:
+     the suffix removed is a greedy match - it contains all the "."s in the
+     input.)
    * if using OpenShift then set this to "/" to show only the project name
      without the cluster and user parts.
 
    If set to the empty string no truncating will occur (this is the default).
 
-   See also: :attr:`LP_ENABLE_KUBECONTEXT`, :attr:`LP_COLOR_KUBECONTEXT`,
+   See also: :attr:`LP_ENABLE_KUBECONTEXT`,
+   :attr:`LP_DELIMITER_KUBECONTEXT_PREFIX`, :attr:`LP_COLOR_KUBECONTEXT`,
    and :attr:`LP_MARK_KUBECONTEXT`.
 
    .. versionadded:: 2.1
@@ -386,7 +414,10 @@ Features
 
    .. _`context`: https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/
 
-   See also: :attr:`LP_DELIMITER_KUBECONTEXT`, :attr:`LP_COLOR_KUBECONTEXT`,
+   See also: :attr:`LP_DELIMITER_KUBECONTEXT`,
+   :attr:`LP_DELIMITER_KUBECONTEXT_PREFIX`,
+   :attr:`LP_DELIMITER_KUBECONTEXT_SUFFIX`,
+   :attr:`LP_COLOR_KUBECONTEXT`,
    and :attr:`LP_MARK_KUBECONTEXT`.
 
    .. versionadded:: 2.1
@@ -1303,4 +1334,3 @@ Valid preset color variables are:
    :value: $GREEN
 
    Color used for indicating that a display is connected.
-

--- a/docs/functions/data.rst
+++ b/docs/functions/data.rst
@@ -52,7 +52,10 @@ Development Environment
    Returns ``true`` if a Kubernetes context is found.
    Returns the Kubernetes context name or the first name component.
 
-   Splitting long context names into components is defined by :attr:`LP_DELIMITER_KUBECONTEXT`.
+   Splitting long context names into components is defined by
+   :attr:`LP_DELIMITER_KUBECONTEXT_SUFFIX` and
+   :attr:`LP_DELIMITER_KUBECONTEXT_PREFIX`. Both use greedy matches - see
+   :doc:`../config` for examples.
 
    Can be disabled by :attr:`LP_ENABLE_KUBECONTEXT`.
 
@@ -434,4 +437,3 @@ Time
    ``0``.
 
    .. versionadded:: 2.0
-

--- a/liquidprompt
+++ b/liquidprompt
@@ -185,7 +185,8 @@ __lp_source_config() {
     LP_PS1_PREFIX=${LP_PS1_PREFIX:-""}
     LP_PS1_POSTFIX=${LP_PS1_POSTFIX:-""}
     LP_MARK_KUBECONTEXT=${LP_MARK_KUBECONTEXT:-"⎈"}
-    LP_DELIMITER_KUBECONTEXT=${LP_DELIMITER_KUBECONTEXT:-""}
+    LP_DELIMITER_KUBECONTEXT_SUFFIX=${LP_DELIMITER_KUBECONTEXT_SUFFIX:-""}
+    LP_DELIMITER_KUBECONTEXT_PREFIX=${LP_DELIMITER_KUBECONTEXT_PREFIX:-""}
 
     LP_ENABLE_PERM=${LP_ENABLE_PERM:-1}
     LP_ENABLE_SHORTEN_PATH=${LP_ENABLE_SHORTEN_PATH:-1}
@@ -1236,8 +1237,12 @@ _lp_kubernetes_context() {
     local kubernetes_context
     kubernetes_context=$(kubectl config current-context 2>/dev/null) || return 1
 
-    if [[ -n "$LP_DELIMITER_KUBECONTEXT" ]]; then
-        kubernetes_context="${kubernetes_context%%${LP_DELIMITER_KUBECONTEXT}*}"
+    if [[ -n "$LP_DELIMITER_KUBECONTEXT_PREFIX" ]]; then
+        kubernetes_context="${kubernetes_context##*${LP_DELIMITER_KUBECONTEXT_PREFIX}}"
+    fi
+
+    if [[ -n "$LP_DELIMITER_KUBECONTEXT_SUFFIX" ]]; then
+        kubernetes_context="${kubernetes_context%%${LP_DELIMITER_KUBECONTEXT_SUFFIX}*}"
     fi
 
     local ret

--- a/liquidpromptrc-dist
+++ b/liquidpromptrc-dist
@@ -170,10 +170,16 @@ LP_ENABLE_SCLS=1
 # Show current Kubernetes kubectl context
 LP_ENABLE_KUBECONTEXT=0
 
-# Delimiter to shorten kubectl context.
+# Delimiter to shorten kubectl context by removing a suffix.
 # E.g. when your context names are dev-cluster and test-cluster, set to "-"
 # in order to output "dev" and "test" in prompt.
-LP_DELIMITER_KUBECONTEXT=
+LP_DELIMITER_KUBECONTEXT_SUFFIX=
+
+# Delimiter to shorten kubectl context by removing a prefix.
+# E.g. when your context names are like
+# arn:aws:eks:$REGION:$ACCOUNT_ID:cluster/$CLUSTER_NAME, set to "/"
+# in order to output "$CLUSTER_NAME" in prompt.
+LP_DELIMITER_KUBECONTEXT_PREFIX=
 
 # Display the current active AWS_PROFILE, if any
 # Recommended value is 1


### PR DESCRIPTION
LP_KUBECONTEXT_DELIMITER (already in liquidprompt) removes a suffix (dev-cluster and - becomes ->
dev). But sometimes the boilerplate part is a prefix, as when using AWS
EKS (Elastic Kubernetes Service), so this adds LP_KUBECONTEXT_DELIMITER_STRIP_PREFIX.

`aws eks update-kubeconfig --name $CLUSTER_NAME` sets the cluster's ARN
as the context name, most of which is boilerplate:
`arn:aws:eks:$REGION:$ACCOUNT_ID:cluster/$CLUSTER_NAME`.