### PR TITLE
Unify project name as "Liquid Prompt" in docs (spelled as two words)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,6 +1,6 @@
 ---
 name: Bug report
-about: Create a report to help us improve Liquidprompt
+about: Create a report to help us improve Liquid Prompt
 title: ''
 labels: 'bug'
 assignees: ''
@@ -27,13 +27,13 @@ Shell:
 -->
 Operating system:
 <!---
-  Liquidprompt version, tag, or commit.
+  Liquid Prompt version, tag, or commit.
   Find with `git describe --tags --exact-match`
   or `git rev-parse HEAD` in the liquidprompt repo.
   Please only report bugs that you have tested against the master branch
   Example: "v1.12"
 -->
-Liquidprompt version: 
+Liquid Prompt version:
 
 ### Steps to Reproduce
 <!--- Provide an unambiguous set of steps to reproduce this bug.
@@ -50,4 +50,3 @@ Liquidprompt version:
 
 ### Possible Solution
 <!--- Optional, suggest an idea for fixing the bug -->
-

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,6 +1,6 @@
 ---
 name: Feature request
-about: Suggest an idea for Liquidprompt
+about: Suggest an idea for Liquid Prompt
 title: ''
 labels: 'enhancement'
 assignees: ''
@@ -17,4 +17,3 @@ assignees: ''
 
 ### Example prompt
 <!--- Show us what a prompt with this feature enabled would look like -->
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -263,7 +263,7 @@ for help.
 - **temperature**: `_lp_temperature()` as data function ([69c75a3])
 - **terminal**: `_lp_terminal_device()` data function ([5076dbe])
 - **tests**: Shunit2 testing suite ([#469], [46918f6], [44e3a6f], [1fe1559])
-- **tests**: Tests to check if a shell supports all features that Liquidprompt
+- **tests**: Tests to check if a shell supports all features that Liquid Prompt
   needs ([46918f6], [5a9293d], [1fe1559])
 - **tests**: Tests for `_lp_as_text()` ([6cdb860])
 - **tests**: Tests for `_lp_battery()`/`acpi` ([cef9cb1])
@@ -325,7 +325,7 @@ for help.
 
 ### Fixed
 - **general**: Issues with custom `$IFS` ([e48856b], [4ebc26e])
-- **general**: Liquidprompt is now `set -u` compatible ([#354], [a8aa8c9], [cb9d71b])
+- **general**: Liquid Prompt is now `set -u` compatible ([#354], [a8aa8c9], [cb9d71b])
 - **acpi**: Temperature check printed each temp twice, slowing down check ([cf8bf97])
 - **acpi**: Temperature check used extended sed syntax without declaring extended language ([eb30942])
 - **battery**: Color display would break with custom `$LP_COLORMAP` array ([f3f20ec])

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ for our standards on shell language.
     $ git clone -o upstream git://github.com/nojhan/liquidprompt.git
     $ cd liquidprompt
 
-    # Run liquidprompt and check that your issue is still on that branch
+    # Run Liquid Prompt and check that your issue is still on that branch
     $ source liquidprompt
 
     # Prepare a fix (include the issue number in the branch name if an issue

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ You can even use it with your favorite shell – Bash or zsh.
 
 ## Documentation
 
-See the [Liquidprompt documentation](https://liquidprompt.readthedocs.io/) for
-details on installing and configuring Liquidprompt.
+See the [Liquid Prompt documentation](https://liquidprompt.readthedocs.io/) for
+details on installing and configuring Liquid Prompt.
 
 
 ## License

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -1,7 +1,7 @@
 # liquidprompt/contrib Policy
 
 This directory contains files that have been contributed by contributors
-but that the core Liquidprompt maintainers do not maintain.
+but that the core Liquid Prompt maintainers do not maintain.
 So they are probably outdated and possibly poor quality (because the maintainers
 may not have the knowledge to properly review them).
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,8 +18,8 @@ import time
 
 # -- Project information -----------------------------------------------------
 
-project = 'Liquidprompt'
-copyright = '2011-%s, Liquidprompt team' % time.strftime('%Y')
+project = 'Liquid Prompt'
+copyright = '2011-%s, Liquid Prompt team' % time.strftime('%Y')
 author = 'Mark Vander Stel'
 
 
@@ -34,9 +34,9 @@ extensions = [
 
 # This value determines how to group the document tree into manual pages
 man_pages = [
-    ('functions', 'liquidprompt', 'Liquidprompt functions', [], 3),
-    ('config', 'liquidprompt', 'Liquidprompt configuration', [], 5),
-    ('theme', 'liquidprompt', 'Liquidprompt theming', [], 7),
+    ('functions', 'liquidprompt', 'Liquid Prompt functions', [], 3),
+    ('config', 'liquidprompt', 'Liquid Prompt configuration', [], 5),
+    ('theme', 'liquidprompt', 'Liquid Prompt theming', [], 7),
 ]
 
 # A URL to cross-reference manpage directives

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -4,9 +4,9 @@ Config Options
 .. contents::
    :local:
 
-Almost every feature in Liquidprompt can be turned on or off using these config
-options. They can either be set before sourcing Liquidprompt (in ``.bashrc`` or
-``.zshrc``), or set in a Liquidprompt config file.
+Almost every feature in Liquid Prompt can be turned on or off using these config
+options. They can either be set before sourcing Liquid Prompt (in ``.bashrc`` or
+``.zshrc``), or set in a Liquid Prompt config file.
 
 .. note::
    Config variables set in a config file take precedence over variables set in the
@@ -26,7 +26,7 @@ The config file is searched for in the following locations:
 
 The first file found is sourced.
 
-Liquidprompt ships with an example config file, ``liquidpromptrc-dist``. You can
+Liquid Prompt ships with an example config file, ``liquidpromptrc-dist``. You can
 start from this file for your config::
 
     cp ~/liquidprompt/liquidpromptrc-dist ~/.config/liquidpromptrc
@@ -127,7 +127,7 @@ General
 
    * **truncate_chars_from_path_left**: Truncates characters from the start of
      the path, showing consecutive directories as one shortened section. E.g. in
-     a directory named ``~/MyProjects/Liquidprompt/tests``, it will be shortened
+     a directory named ``~/MyProjects/liquidprompt/tests``, it will be shortened
      to ``...prompt/tests``. The shortened mark is :attr:`LP_MARK_SHORTEN_PATH`.
    * **truncate_chars_from_dir_right**: Leaves the beginning of a directory name
      untouched. E.g. directories will be shortened like so: ``~/Doc.../Office``.
@@ -344,7 +344,7 @@ Features
       example, Docker doesn't inherit anything unless explicitly told to.
       Singularity in many configurations inherits most variables but shell
       functions and zsh hooks might not make it in.  For full functionality,
-      liquidprompt may need to be sourced inside the child container.
+      ``liquidprompt`` may need to be sourced inside the child container.
 
    See also: :attr:`LP_COLOR_CONTAINER`.
 

--- a/docs/functions.rst
+++ b/docs/functions.rst
@@ -8,7 +8,7 @@ Functions starting with ``_lp`` are **theme** level functions, designed to be us
 by themes. These include data, theme, and utility functions.
 
 Functions starting with ``__lp`` are **internal** functions, designed to be used
-only by Liquidprompt internals. These functions should not be used by users or
+only by Liquid Prompt internals. These functions should not be used by users or
 themes, as they are not guaranteed to not change between versions.
 
 .. toctree::

--- a/docs/functions/data/vcs.rst
+++ b/docs/functions/data/vcs.rst
@@ -63,7 +63,7 @@ this.
 
 .. function:: _lp_vcs_active()
 
-   Returns ``true`` if the detected VCS is enabled in Liquidprompt and the
+   Returns ``true`` if the detected VCS is enabled in Liquid Prompt and the
    current directory is a valid repository of that type. This check should be
    done before running any other ``_lp_vcs_*`` data functions, but can be
    omitted for speed reasons if the checks done by :func:`_lp_find_vcs` are good
@@ -262,7 +262,7 @@ Bazaar
 
 .. function:: _lp_bzr_active()
 
-   Returns ``true`` if Bazaar is enabled in Liquidprompt and the current
+   Returns ``true`` if Bazaar is enabled in Liquid Prompt and the current
    directory is a valid Bazaar repository. This check should be done before
    running any other ``_lp_bzr_*`` data functions if accessing the Bazaar
    data functions directly instead of through the generic interface.
@@ -347,7 +347,7 @@ Fossil
 
 .. function:: _lp_fossil_active()
 
-   Returns ``true`` if Fossil is enabled in Liquidprompt and the current
+   Returns ``true`` if Fossil is enabled in Liquid Prompt and the current
    directory is a valid Fossil repository. This check should be done before
    running any other ``_lp_fossil_*`` data functions if accessing the Fossil
    data functions directly instead of through the generic interface.
@@ -419,7 +419,7 @@ Git
 
 .. function:: _lp_git_active()
 
-   Returns ``true`` if Git is enabled in Liquidprompt and the current directory
+   Returns ``true`` if Git is enabled in Liquid Prompt and the current directory
    is a valid Git repository. This check should be done before running any other
    ``_lp_git_*`` data functions if accessing the Git data functions directly
    instead of through the generic interface.
@@ -547,7 +547,7 @@ Mercurial
 
 .. function:: _lp_hg_active()
 
-   Returns ``true`` if Mercurial is enabled in Liquidprompt and the current
+   Returns ``true`` if Mercurial is enabled in Liquid Prompt and the current
    directory is a valid Mercurial repository. This check should be done before
    running any other ``_lp_hg_*`` data functions if accessing the Mercurial data
    functions directly instead of through the generic interface.
@@ -677,7 +677,7 @@ Subversion
 
 .. function:: _lp_svn_active()
 
-   Returns ``true`` if Subversion is enabled in Liquidprompt and the current
+   Returns ``true`` if Subversion is enabled in Liquid Prompt and the current
    directory is a valid Subversion repository. This check should be done before
    running any other ``_lp_svn_*`` data functions if accessing the Subversion
    data functions directly instead of through the generic interface.

--- a/docs/functions/internal.rst
+++ b/docs/functions/internal.rst
@@ -4,10 +4,10 @@ Internal Functions
 .. contents::
    :local:
 
-These functions are designed to be used only by Liquidprompt internals and data
+These functions are designed to be used only by Liquid Prompt internals and data
 functions. These functions should not be used by users or themes, as they are
 not guaranteed to be stable between versions. There are documented here for
-information for those developing Liquidprompt.
+information for those developing Liquid Prompt.
 
 Config
 ------
@@ -219,7 +219,7 @@ Theme
 
 .. function:: __lp_theme_list() -> var:lp_theme_list
 
-   Returns an array of Liquidprompt themes currently loaded in memory. Looks for
+   Returns an array of Liquid Prompt themes currently loaded in memory. Looks for
    functions matching ``_lp_*_theme_prompt``.
 
    .. versionadded:: 2.0

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,17 +1,17 @@
-.. Liquidprompt documentation master file, created by
+.. Liquid Prompt documentation master file, created by
    sphinx-quickstart on Wed Nov 18 11:00:53 2020.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to Liquidprompt's documentation!
-========================================
+Welcome to Liquid Prompt's documentation!
+=========================================
 
-Liquidprompt is an adaptive prompt for Bash & Zsh that gives you a nicely
+Liquid Prompt is an adaptive prompt for Bash & Zsh that gives you a nicely
 displayed prompt with useful information when you need it. It does this with a
 powerful theming engine and a large array of data sources.
 
 To get started, view the :doc:`install` documentation, which includes
-instructions for trying Liquidprompt temporarily.
+instructions for trying Liquid Prompt temporarily.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -47,7 +47,7 @@ add the following lines in your ``.zshrc`` after activating Zinit::
 Dependencies
 ============
 
-Liquidprompt uses commands that should be available on a large variety of Unix
+Liquid Prompt uses commands that should be available on a large variety of Unix
 systems:
 
    * ``awk``
@@ -83,10 +83,10 @@ Adjust the path if you installed to a different location that the suggested
 Shell Installation
 ==================
 
-To use Liquidprompt every time you start a shell, add the following lines to
+To use Liquid Prompt every time you start a shell, add the following lines to
 your ``.bashrc`` (if you use Bash) or ``.zshrc`` (if you use zsh)::
 
-   # Only load Liquidprompt in interactive shells, not from a script or from scp
+   # Only load Liquid Prompt in interactive shells, not from a script or from scp
    [[ $- = *i* ]] && source ~/liquidprompt/liquidprompt
 
 Adjust the path if you installed to a different location that the suggested
@@ -96,7 +96,7 @@ Adjust the path if you installed to a different location that the suggested
    Check in your ``.bashrc`` that the :envvar:`PROMPT_COMMAND` variable is not
    set, or else the prompt will not be available. If you must set it or use a
    add-on that sets it, make sure to set :envvar:`PROMPT_COMMAND` **before** you
-   source Liquidprompt to avoid history and timing issues. Do not export
+   source Liquid Prompt to avoid history and timing issues. Do not export
    :envvar:`PROMPT_COMMAND`.
 
 .. warning::

--- a/docs/install/packages.rst
+++ b/docs/install/packages.rst
@@ -4,14 +4,14 @@ Packages
 .. contents::
    :local:
 
-Liquidprompt is packaged for many operating systems, though the latest version
+Liquid Prompt is packaged for many operating systems, though the latest version
 in those repositories is not always up to date.
 
 Latest Versions
 ===============
 
 .. image:: https://repology.org/badge/vertical-allrepos/liquidprompt.svg
-   :alt: Liquidprompt packaging status
+   :alt: Liquid Prompt packaging status
 
 Source: `repology.org <https://repology.org/project/liquidprompt/versions>`_.
 
@@ -56,11 +56,11 @@ used instead of the :ref:`shell-installation` instructions.
 
 This will set the required environment:
 
-* The files ``~/.bashrc`` and/or ``~/.zshrc`` are modified to load Liquidprompt
+* The files ``~/.bashrc`` and/or ``~/.zshrc`` are modified to load Liquid Prompt
   at startup.
 * If no previous ``~/.config/liquidpromptrc`` file exists, it will be created.
 
-So, to get Liquidprompt working simply run:
+So, to get Liquid Prompt working simply run:
 
 .. code-block::
 

--- a/docs/release-notes/v1.12.rst
+++ b/docs/release-notes/v1.12.rst
@@ -27,7 +27,7 @@ Preset Color Aliases
 ====================
 
 The ``5`` value of the basic colors is often named "magenta", but in
-Liquidprompt it has always been "purple", and the bold version is "pink".
+Liquid Prompt it has always been "purple", and the bold version is "pink".
 
 To make the options more standard, an alias for ``PURPLE`` is ``MAGENTA``, and
 ``PINK`` now has aliases of ``BOLD_PURPLE`` and ``BOLD_MAGENTA``.

--- a/docs/release-notes/v2.0.rst
+++ b/docs/release-notes/v2.0.rst
@@ -24,7 +24,7 @@ See :doc:`../theme`.
 Example Themes
 ==============
 
-Liquidprompt now ships with some example themes showcasing how the new theme
+Liquid Prompt now ships with some example themes showcasing how the new theme
 engine works. They are also fulling working themes that you can use as your
 daily drivers.
 See :doc:`../theme/included`.
@@ -32,7 +32,7 @@ See :doc:`../theme/included`.
 Data Sources
 ============
 
-To power the themes, all of the data sources in Liquidprompt have been broken
+To power the themes, all of the data sources in Liquid Prompt have been broken
 out into individual data functions that can be called by themes. They are also
 documented in detail in :doc:`../functions/data`.
 
@@ -61,9 +61,9 @@ See :doc:`../functions/theme`.
 Version Control Tracking updates without directory change
 =========================================================
 
-Before, if ``git init`` or similar was run in a directory, Liquidprompt would
+Before, if ``git init`` or similar was run in a directory, Liquid Prompt would
 not display any repository information until the current directory was changed.
-Thanks to the speed improvements, Liquidprompt now checks for a repository at
+Thanks to the speed improvements, Liquid Prompt now checks for a repository at
 each prompt, while still being faster than version 1.12.
 
 Activate Function

--- a/docs/release-notes/v2.1.rst
+++ b/docs/release-notes/v2.1.rst
@@ -10,7 +10,7 @@ fixes.
 Title Command
 =============
 
-Liquidprompt can now display the currently running command as part of the
+Liquid Prompt can now display the currently running command as part of the
 terminal title. See :attr:`LP_ENABLE_TITLE_COMMAND` for more information.
 
 Development Environments
@@ -61,7 +61,7 @@ few issues, and will help prevent regressions.
 Bash-preexec Compatibility
 ==========================
 
-Liquidprompt now supports running along side `bash-preexec`_. Simply load
-Liquidprompt `after` bash-preexec.
+Liquid Prompt now supports running along side `bash-preexec`_. Simply load
+Liquid Prompt `after` bash-preexec.
 
 .. _bash-preexec: https://github.com/rcaloras/bash-preexec

--- a/docs/theme.rst
+++ b/docs/theme.rst
@@ -1,21 +1,21 @@
 Theming
 *******
 
-Liquidprompt has a strong data and theming engine, allowing it to be extremely
+Liquid Prompt has a strong data and theming engine, allowing it to be extremely
 flexible and customizable.
 
 The :doc:`theme/default` has a templating engine (previously called "themes" in
-Liquidprompt version 1), that allows for custom prompt ordering in the default
+Liquid Prompt version 1), that allows for custom prompt ordering in the default
 theme.
 
-Liquidprompt ships with some :doc:`theme/included` other than the default as
+Liquid Prompt ships with some :doc:`theme/included` other than the default as
 well.
 
-See the `Liquidprompt Theme List`_ on the wiki for user created themes.
+See the `Liquid Prompt Theme List`_ on the wiki for user created themes.
 
 If you want to create your own theme, see :doc:`theme/custom`.
 
-.. _`Liquidprompt Theme List`: https://github.com/nojhan/liquidprompt/wiki/Themes
+.. _`Liquid Prompt Theme List`: https://github.com/nojhan/liquidprompt/wiki/Themes
 
 .. toctree::
    :maxdepth: 2
@@ -30,7 +30,7 @@ If you want to create your own theme, see :doc:`theme/custom`.
 Switching Themes
 ----------------
 
-Liquidprompt can switch between themes on the fly. The shell does not need to be
+Liquid Prompt can switch between themes on the fly. The shell does not need to be
 reloaded, and no files need to be sourced after the initial source.
 
 To load (but not activate) a theme, simply source the theme file. For example,

--- a/docs/theme/default.rst
+++ b/docs/theme/default.rst
@@ -9,7 +9,7 @@ Preview
 =======
 
 If there is nothing special about the current context, the appearance of
-Liquidprompt is similar to that of a default prompt:
+Liquid Prompt is similar to that of a default prompt:
 
 .. image:: default-short.png
    :alt: [user:~] $
@@ -20,7 +20,7 @@ Git repository on a server:
 .. image:: default-med.png
    :alt: 1& [user@server:~/liquidprompt] main ±
 
-When Liquidprompt is displaying nearly everything (a rare event!), it may look
+When Liquid Prompt is displaying nearly everything (a rare event!), it may look
 like this:
 
 .. image:: default-long.png
@@ -57,7 +57,7 @@ to a variable, and can be arranged in any order in a template. If you want to
 change the theme enough to move things around, but not enough to make your own
 theme, templates will let you change the order of the default theme's pieces.
 
-As the default theme of Liquidprompt was the only theme until version 2.0,
+As the default theme of Liquid Prompt was the only theme until version 2.0,
 templates were sometimes referred to as "themes" in version 1.X.
 
 For a template file to be loaded, its filepath must be set in
@@ -78,7 +78,7 @@ default order if the user does not configure a different template.
 
 .. note::
    Omitting a template section from your template will **not** disable that
-   feature. While it will not be displayed in the prompt, Liquidprompt does not
+   feature. While it will not be displayed in the prompt, Liquid Prompt does not
    know that, and will still generate that template section. If you want to
    speed up your prompt by disabling a section, you must disable it with its
    respective ``LP_ENABLE_*`` option.

--- a/docs/theme/included.rst
+++ b/docs/theme/included.rst
@@ -1,8 +1,8 @@
 Included Themes
 ***************
 
-Liquidprompt ships with some included themes that will have features added to
-them as they are added to Liquidprompt.
+Liquid Prompt ships with some included themes that will have features added to
+them as they are added to Liquid Prompt.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/theme/included/alternate_vcs.rst
+++ b/docs/theme/included/alternate_vcs.rst
@@ -36,7 +36,7 @@ Git repository on a server:
 .. image:: alternate_vcs-med.png
    :alt: 1& [user@server:~/liquidprompt] main ±
 
-When Liquidprompt is displaying nearly everything, it may look like this:
+When Liquid Prompt is displaying nearly everything, it may look like this:
 
 .. image:: alternate_vcs-long.png
    :alt: 🕤 ⌁24% ⌂1.68 θ90° 3d/2&/1z [user@server:~/ … /liquidprompt/docs/theme ⚞3] [pyenv] main(U2 ?1 +10/-5,+3/-1)+ 20s 125 ±
@@ -49,9 +49,9 @@ A demo of what disabling the configuration options might look like:
 Configuration
 =============
 
-Liquidprompt Configuration
---------------------------
-All Liquidprompt config options are respected, **except for**:
+Liquid Prompt Configuration
+---------------------------
+All Liquid Prompt config options are respected, **except for**:
 
 * :attr:`LP_MARK_UNTRACKED` when :attr:`LP_ENABLE_ALT_VCS_STATUS` is enabled.
 
@@ -102,4 +102,3 @@ _______
    :value: "🔖"
 
    The marker string used to indicate the following string is a VCS tag.
-

--- a/docs/theme/included/powerline.rst
+++ b/docs/theme/included/powerline.rst
@@ -13,7 +13,7 @@ Powerline
 The ``powerline`` theme is a clone of the `Powerline prompt`_. It copies the
 `default segments`_ of the Powerline prompt for Shell.
 
-This prompt is a proof of (a specific) concept: that Liquidprompt can do what
+This prompt is a proof of (a specific) concept: that Liquid Prompt can do what
 Powerline does, but faster.
 That said, this is a fully usable theme.
 
@@ -37,14 +37,14 @@ Git repository on a server:
 .. image:: powerline-med.png
    :alt:   server  user  ~  liquidprompt  1   main  
 
-When Liquidprompt is displaying nearly everything, it may look like this:
+When Liquid Prompt is displaying nearly everything, it may look like this:
 
 .. image:: powerline-long.png
    :alt:   server  user  (e) pyenv  ~   …   liquidprompt   …   theme  3   main  ST 1  125  
 
 .. note::
    The above "everything" image looks like it is missing some parts because this
-   theme does not implement all data sources of Liquidprompt. This is by design
+   theme does not implement all data sources of Liquid Prompt. This is by design
    to clone basic Powerline. For a Powerline theme that does show all data
    sources, see :ref:`Powerline Full <powerline_full>` below.
 
@@ -62,9 +62,9 @@ See the `Powerline Fonts installation docs`_ for help.
 Configuration
 =============
 
-Liquidprompt Configuration
---------------------------
-The following Liquidprompt config options are respected:
+Liquid Prompt Configuration
+---------------------------
+The following Liquid Prompt config options are respected:
 
 * :attr:`LP_DISABLED_VCS_PATHS`
 * :attr:`LP_ENABLE_BZR`
@@ -257,7 +257,7 @@ Powerline Full
 **************
 
 An extension of the ``powerline`` theme, ``powerline_full`` includes all data
-sources that Liquidprompt provides. The ordering is the same as the default
+sources that Liquid Prompt provides. The ordering is the same as the default
 theme.
 
 .. versionadded:: 2.0
@@ -277,7 +277,7 @@ Git repository on a server:
 .. image:: powerline_full-med.png
    :alt:  1&  user   server  ~  liquidprompt  main  
 
-When Liquidprompt is displaying nearly everything, it may look like this:
+When Liquid Prompt is displaying nearly everything, it may look like this:
 
 .. image:: powerline_full-long.png
    :alt:  🕤  ⌁24%  ⌂1.68  θ90°  3d/2&/1z  user   server  ~   …   liquidprompt   …   theme  ⚞3  (e) pyenv  main(+10/-5,+3/-1)+*  20s  125  
@@ -291,9 +291,9 @@ See the `Powerline Fonts installation docs`_ for help.
 Configuration
 =============
 
-Liquidprompt Configuration
---------------------------
-All Liquidprompt config options are respected, **except for**:
+Liquid Prompt Configuration
+---------------------------
+All Liquid Prompt config options are respected, **except for**:
 
 * :attr:`LP_COLOR_AWS_PROFILE`
 * :attr:`LP_COLOR_CONTAINER`

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -1,7 +1,7 @@
-Upgrading Liquidprompt
+Upgrading Liquid Prompt
 **********************
 
-We try our best to make new versions of Liquidprompt backwards compatible with
+We try our best to make new versions of Liquid Prompt backwards compatible with
 previous versions, but sometimes things need to change to make forward progress.
 If a version introduces breaking changes or deprecation notices, a detailed
 document describing what changes a user needs to make will be linked below.

--- a/liquidprompt
+++ b/liquidprompt
@@ -1840,7 +1840,7 @@ _lp_vcs_details_color() {
     lp_vcs_details_color+="$NO_COL"
 }
 
-# Check if the detected VCS is enabled in Liquidprompt and the current
+# Check if the detected VCS is enabled in Liquid Prompt and the current
 # directory is a valid repository of that type.
 _lp_vcs_active() {
     "_lp_${lp_vcs_type}_active"
@@ -1919,7 +1919,7 @@ _lp_vcs_staged_lines() {
 
 # GIT #
 
-# Check if Git is enabled in Liquidprompt and the current directory is a valid
+# Check if Git is enabled in Liquid Prompt and the current directory is a valid
 # Git repository.
 _lp_git_active() {
     (( LP_ENABLE_GIT )) || return 2
@@ -2141,7 +2141,7 @@ _lp_git_staged_lines() {
 
 # MERCURIAL #
 
-# Check if Mercurial is enabled in Liquidprompt and the current directory is a
+# Check if Mercurial is enabled in Liquid Prompt and the current directory is a
 # valid Mercurial repository.
 _lp_hg_active() {
     (( LP_ENABLE_HG )) || return 2
@@ -2258,7 +2258,7 @@ _lp_hg_staged_lines() { return 2 ; }
 
 # SUBVERSION #
 
-# Check if Subversion is enabled in Liquidprompt and the current directory is a
+# Check if Subversion is enabled in Liquid Prompt and the current directory is a
 # valid Subversion repository.
 _lp_svn_active() {
     (( LP_ENABLE_SVN )) || return 2
@@ -2351,7 +2351,7 @@ _lp_svn_staged_lines() { return 2 ; }
 
 # FOSSIL #
 
-# Check if Fossil is enabled in Liquidprompt and the current directory is a
+# Check if Fossil is enabled in Liquid Prompt and the current directory is a
 # valid Fossil repository.
 _lp_fossil_active() {
     (( LP_ENABLE_FOSSIL )) || return 2
@@ -2464,7 +2464,7 @@ _lp_fossil_staged_lines() { return 2 ; }
 
 # Bazaar #
 
-# Check if Bazaar is enabled in Liquidprompt and the current directory is a
+# Check if Bazaar is enabled in Liquid Prompt and the current directory is a
 # valid Bazaar repository. This check should be done before running any other
 # _lp_bzr_* data functions.
 _lp_bzr_active() {
@@ -3698,7 +3698,7 @@ lp_theme() {
 
     if [[ -z $theme ]]; then
         printf '%s\n%s\n' \
-            'Must pass in the name of a theme. If you meant the default Liquidprompt theme, try "default".' \
+            'Must pass in the name of a theme. If you meant the default Liquid Prompt theme, try "default".' \
             'Run "lp_theme --list" to see all loaded and available themes.' 2>&1
         return 1
     fi
@@ -3723,7 +3723,7 @@ lp_theme() {
     prompt_on
 }
 
-# By default, sourcing liquidprompt will activate Liquid Prompt
+# By default, sourcing 'liquidprompt' will activate Liquid Prompt
 if [ "${1-}" != "--no-activate" ]; then
     lp_activate
 fi

--- a/tests/test_ruby.sh
+++ b/tests/test_ruby.sh
@@ -4,7 +4,7 @@ set -u
 
 . ../liquidprompt --no-activate
 
-# Liquidprompt depends on PS1 being set to detect if it has installed itself.
+# Liquid Prompt depends on PS1 being set to detect if it has installed itself.
 PS1="$ "
 
 LP_ENABLE_RUBY_VENV=1

--- a/tools/theme-preview.sh
+++ b/tools/theme-preview.sh
@@ -9,7 +9,7 @@ if [[ -z ${1-} || $1 == --help ]]; then
 Usage: %s theme [sourced files...]
 
 Print out example prompts based on a standard set of input conditions. Designed
-to showcase Liquidprompt themes.
+to showcase Liquid Prompt themes.
 
 Example usage: %s powerline themes/powerline/powerline.theme
 ' "$0" "$0"
@@ -25,7 +25,7 @@ else
   done
 fi
 
-# Liquidprompt depends on PS1 being set to detect if it has installed itself.
+# Liquid Prompt depends on PS1 being set to detect if it has installed itself.
 PS1="$ "
 
 # Since the shell is not evaluating PS1, we don't need these.


### PR DESCRIPTION
On the front page README.md the project name is spelled "Liquid Prompt" as two words. This PR suggests to use that spelling across all project documentation.