### PR TITLE
Add AWS Vault support

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -271,11 +271,14 @@ Features
    :type: bool
    :value: 1
 
-   Display the current value of :envvar:`AWS_PROFILE` or
-   :envvar:`AWS_DEFAULT_PROFILE`. These variables are used to switch between
-   configuration profiles by the `AWS CLI`_.
+   Display the current value of :envvar:`AWS_PROFILE`,
+   :envvar:`AWS_DEFAULT_PROFILE`, or :envvar:`AWS_VAULT`. AWS_PROFILE and
+   AWS_DEFAULT_PROFILE are used to switch between configuration profiles by
+   the `AWS CLI`_. AWS_VAULT is used by `aws-vault`_ to specify the AWS
+   profile in use.
 
    .. _`AWS CLI`: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html
+   .. _`aws-vault`: https://github.com/99designs/aws-vault
 
    See also: :attr:`LP_COLOR_AWS_PROFILE`.
 

--- a/docs/functions/data.rst
+++ b/docs/functions/data.rst
@@ -113,9 +113,9 @@ Environment
 
 .. function:: _lp_aws_profile() -> var:lp_aws_profile
 
-   Returns ``true`` if the :envvar:`AWS_PROFILE` or :envvar:`AWS_DEFAULT_PROFILE`
-   variables are found in the environment (in that order of preference).
-   Returns the contents of the variable.
+   Returns ``true`` if the :envvar:`AWS_PROFILE`, :envvar:`AWS_DEFAULT_PROFILE`,
+   or :envvar:`AWS_VAULT` variables are found in the environment
+   (in that order of preference). Returns the contents of the variable.
 
    Can be disabled by :attr:`LP_ENABLE_AWS_PROFILE`.
 

--- a/liquidprompt
+++ b/liquidprompt
@@ -1414,7 +1414,7 @@ _lp_aws_profile() {
 
     local ret
 
-    local aws_profile="${AWS_PROFILE-${AWS_DEFAULT_PROFILE-}}"
+    local aws_profile="${AWS_PROFILE-${AWS_DEFAULT_PROFILE-${AWS_VAULT-}}}"
     if [[ -n $aws_profile ]]; then
         __lp_escape "${aws_profile}"
         lp_aws_profile=$ret


### PR DESCRIPTION
Extension to #496 to add [AWS Vault](https://github.com/99designs/aws-vault) support. AWS Vault does not set the AWS_PROFILE/AWS_DEFAULT_PROFILE variables, but does add AWS_VAULT. Since this is philosophically the same as showing an AWS profile on the prompt, I simply added AWS_VAULT to the detection chain.