### PR TITLE
Add Kubernetes context default namespace

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -417,7 +417,24 @@ Features
 
    .. _`context`: https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/
 
-   See also: :attr:`LP_DELIMITER_KUBECONTEXT`,
+   See also: :attr:`LP_ENABLE_KUBE_NAMESPACE`,
+   :attr:`LP_DELIMITER_KUBECONTEXT_PREFIX`,
+   :attr:`LP_DELIMITER_KUBECONTEXT_SUFFIX`,
+   :attr:`LP_COLOR_KUBECONTEXT`,
+   and :attr:`LP_MARK_KUBECONTEXT`.
+
+   .. versionadded:: 2.1
+
+.. attribute:: LP_ENABLE_KUBE_NAMESPACE
+   :type: bool
+   :value: 0
+
+   Display the current `Kubernetes <https://kubernetes.io/>`_ default
+   `namespace`_ in the current context.
+
+   .. _`namespace`: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/#setting-the-namespace-preference
+
+   See also: :attr:`LP_ENABLE_KUBECONTEXT`,
    :attr:`LP_DELIMITER_KUBECONTEXT_PREFIX`,
    :attr:`LP_DELIMITER_KUBECONTEXT_SUFFIX`,
    :attr:`LP_COLOR_KUBECONTEXT`,

--- a/docs/functions/data.rst
+++ b/docs/functions/data.rst
@@ -47,7 +47,7 @@ Battery
 Development Environment
 -----------------------
 
-.. function:: _lp_kubernetes_context() -> var:lp_kubernetes_context
+.. function:: _lp_kubernetes_context() -> var:lp_kubernetes_context, var:lp_kubernetes_namespace
 
    Returns ``true`` if a Kubernetes context is found.
    Returns the Kubernetes context name or the first name component.
@@ -56,6 +56,9 @@ Development Environment
    :attr:`LP_DELIMITER_KUBECONTEXT_SUFFIX` and
    :attr:`LP_DELIMITER_KUBECONTEXT_PREFIX`. Both use greedy matches - see
    :doc:`../config` for examples.
+
+   If enabled by :attr:`LP_ENABLE_KUBE_NAMESPACE`, will also return the default
+   namespace for the current context, if one is set.
 
    Can be disabled by :attr:`LP_ENABLE_KUBECONTEXT`.
 

--- a/liquidprompt
+++ b/liquidprompt
@@ -1236,11 +1236,14 @@ _lp_kubernetes_context() {
     (( LP_ENABLE_KUBECONTEXT )) || return 2
 
     local kubernetes_context
-    kubernetes_context=$(kubectl config current-context 2>/dev/null) || return 1
 
     if (( LP_ENABLE_KUBE_NAMESPACE )); then
-        local kubernetes_namespace
-        kubernetes_namespace=$(kubectl config view --minify --output 'jsonpath={..namespace}') || return 1
+        local line kubernetes_namespace
+        line=$(kubectl config view --minify --output 'jsonpath={.current-context}{"/"}{..namespace}')
+        kubernetes_context=${line%/*}
+        kubernetes_namespace=${line##*/}
+    else
+        kubernetes_context=$(kubectl config current-context 2>/dev/null) || return 1
     fi
 
     if [[ -n "$LP_DELIMITER_KUBECONTEXT_PREFIX" ]]; then

--- a/liquidprompt
+++ b/liquidprompt
@@ -224,6 +224,7 @@ __lp_source_config() {
     LP_ENABLE_ERROR=${LP_ENABLE_ERROR:-1}
     LP_ENABLE_DIRSTACK=${LP_ENABLE_DIRSTACK:-0}
     LP_ENABLE_KUBECONTEXT=${LP_ENABLE_KUBECONTEXT:-0}
+    LP_ENABLE_KUBE_NAMESPACE=${LP_ENABLE_KUBE_NAMESPACE:-0}
 
     LP_MARK_DEFAULT="${LP_MARK_DEFAULT:-$_LP_MARK_SYMBOL}"
     LP_MARK_BATTERY="${LP_MARK_BATTERY:-"⌁"}"
@@ -1237,6 +1238,11 @@ _lp_kubernetes_context() {
     local kubernetes_context
     kubernetes_context=$(kubectl config current-context 2>/dev/null) || return 1
 
+    if (( LP_ENABLE_KUBE_NAMESPACE )); then
+        local kubernetes_namespace
+        kubernetes_namespace=$(kubectl config view --minify --output 'jsonpath={..namespace}') || return 1
+    fi
+
     if [[ -n "$LP_DELIMITER_KUBECONTEXT_PREFIX" ]]; then
         kubernetes_context="${kubernetes_context##*${LP_DELIMITER_KUBECONTEXT_PREFIX}}"
     fi
@@ -1248,12 +1254,19 @@ _lp_kubernetes_context() {
     local ret
     __lp_escape "$kubernetes_context"
     lp_kubernetes_context=$ret
+
+    if [[ -n ${kubernetes_namespace-} ]]; then
+        __lp_escape "$kubernetes_namespace"
+        lp_kubernetes_namespace=$ret
+    else
+        unset lp_kubernetes_namespace
+    fi
 }
 
 _lp_kubernetes_context_color() {
     _lp_kubernetes_context || return "$?"
 
-    lp_kubernetes_context_color="[${LP_MARK_KUBECONTEXT}${LP_COLOR_KUBECONTEXT}${lp_kubernetes_context}${NO_COL}]"
+    lp_kubernetes_context_color="[${LP_MARK_KUBECONTEXT}${LP_COLOR_KUBECONTEXT}${lp_kubernetes_context}${lp_kubernetes_namespace+:}${lp_kubernetes_namespace-}${NO_COL}]"
 }
 
 # Same as bash '\l', but can be inlined as a constant as the value will not


### PR DESCRIPTION
Add data gathering for the configured default **namespace** of the current `kubectl` context. Display that data as a string directly after the context string, separated by a colon.

See [Setting the namespace preference](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/#setting-the-namespace-preference) in the Kubernetes docs.

Example:
```[⎈cluster:my-namespace]```

While this is a separate chunk of data from the context, it is actually part of the context definition, and so it makes sense to display it along with the context.

While most Kubernetes objects are subject to the strict DNS name restrictions, kubectl contexts never have their name server-side, and so do not have the same restrictions. This means a context name can include any characters, meaning we have no safe way to parse it out of a data string. I wanted to use:

```bash
line=$(kubectl config view --minify --output 'jsonpath={.current-context}{" "}{..namespace}')
IFS=' ' read kubernetes_context kubernetes_namespace <<<"$line"
```

But since spaces can be in a context name, this would break.

CC: @imsky @mschuett @lyoshenka @ismith

Questions:
1. Is this data you want to see? I know it is for me, but do others want it?
2. Would you want this displayed in a different way?
3. Should the delimiter (`:`) be configurable? Especially since `kubectl` does not limit what characters can be in context names, so a colon could be part of a name.
4. Can you think of a better way to get this data? I really want to do it in one call instead of two, but I can't find a way to do it safely since a context can contain whatever character we pick for a delimiter.