### PR TITLE
Add option to choose which battery status to get

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -187,6 +187,20 @@ General
 
 Features
 --------
+.. attribute:: LP_BATTERY_ID
+   :type: int
+   :value: 0
+
+   Select which battery to use when monitoring level and charging status.
+   Works only with ACPI method of obtaining battery information.
+   Usage example:
+   
+   * Default value for this option is ``0``, meaning default battery will
+     be used when monitoring battery level and charging status.
+   * Any other value must be a valid battery ID. Can be obtained by running
+     ``acpi --battery`` and getting the appropriate ID from the printout.
+
+   .. versionadded:: 2.1
 
 .. attribute:: LP_DELIMITER_KUBECONTEXT_PREFIX
    :type: string

--- a/docs/functions/data.rst
+++ b/docs/functions/data.rst
@@ -44,6 +44,9 @@ Battery
 
    Can be disabled by :attr:`LP_ENABLE_BATT`.
 
+   .. versionchanged:: 2.1
+      :attr:`LP_BATTERY_ID` can be used to specify which battery to monitor.
+
 Development Environment
 -----------------------
 

--- a/liquidprompt
+++ b/liquidprompt
@@ -2352,6 +2352,7 @@ case "$LP_OS" in
                 # Find the desired battery by it's ID
                 if [[ $line =~ Battery\ $LP_BATTERY_ID ]]; then
                     acpi=$line # Use only desired battery output
+                    break
                 fi
             done <<<"$acpi"
         fi

--- a/liquidpromptrc-dist
+++ b/liquidpromptrc-dist
@@ -20,7 +20,7 @@
 # Recommended value is 75
 LP_BATTERY_THRESHOLD=75
 
-# Use particular battery IDwhen multiple batteries are reported by ACPI
+# Use particular battery ID when multiple batteries are reported by ACPI
 # and the default one is wrong.
 # Example of such behaviour is when using Logitech Unified Receiver
 # and ACPI reports keyboard and mouse batteries first, and laptop battery last

--- a/tests/test_acpi.sh
+++ b/tests/test_acpi.sh
@@ -10,7 +10,7 @@ unset -f uname
 
 LP_ENABLE_BATT=1
 
-typeset -a battery_outputs battery_statuses battery_values temp_outputs temp_values
+typeset -a battery_outputs battery_statuses battery_values temp_outputs temp_values battery_ids
 
 # Add test cases to these arrays like below
 
@@ -19,6 +19,7 @@ battery_outputs+=(
 ""
 )
 battery_statuses+=(4)
+battery_ids+=("")
 battery_values+=("")
 temp_outputs+=(
 "Thermal 0: ok, 23.0 degrees C"
@@ -31,10 +32,25 @@ battery_outputs+=(
 )
 battery_statuses+=(0)
 battery_values+=(55)
+battery_ids+=(0)
 temp_outputs+=(
 "Thermal 0: ok, -267.8 degrees C"
 )
 temp_values+=(-267)
+
+# Multiple batteries
+battery_outputs+=(
+"Battery 0: Discharging, 0%, rate information unavailable
+Battery 1: Discharging, 0%, rate information unavailable
+Battery 2: Discharging, 53%, 02:35:00 remaining"
+)
+battery_statuses+=(0)
+battery_values+=(53)
+battery_ids+=(2)
+temp_outputs+=(
+"Thermal 0: ok, 39.0 degrees C"
+)
+temp_values+=(39)
 
 # VPS at OVH
 temp_outputs+=(
@@ -50,6 +66,7 @@ function test_acpi_battery {
 
   for (( index=0; index < ${#battery_values[@]}; index++ )); do
     __battery_output=${battery_outputs[$index]}
+    LP_BATTERY_ID=${battery_ids[$index]}
 
     LP_BATTERY_THRESHOLD=100
     _lp_battery


### PR DESCRIPTION
In an instance that ACPI reports multiple batteries, having an option to specify which one to use could be very useful.

For example, I am using Logitech Unifying Receiver, and it reports back battery information of my keyboard and mouse (wrong information I might add, as can be seen on the screenshot)
![acpi-battery](https://user-images.githubusercontent.com/4169512/137388764-c331ec6a-03c4-460f-9470-a8be5c55dd2f.png)


 In this case, those two come before my actual laptop battery (Battery 2), and because of this, I always get the 0% state.

I have added the option LP_BATTERY_ID, with the default of 0, so that users can specify which battery they want to read.