### PR TITLE
Early exit on TERM=unknown

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -22,7 +22,7 @@
 
 # Issue #161: do not load if not an interactive shell
 # Do not exit if '--no-activate' flag was passed, as it overrides this check
-[ "x${-##*i}" = "x$-" ] || [ -z "${TERM-}" ] || [ "x${TERM-}" = xdumb ] && [ "x${1-}" != "x--no-activate" ] && return
+[ "x${-##*i}" = "x$-" ] || [ -z "${TERM-}" ] || [ "x${TERM-}" = xdumb ] && [ "x${TERM-}" = xunknown ] && [ "x${1-}" != "x--no-activate" ] && return
 
 if test -n "${BASH_VERSION-}"; then
     # Check for recent enough version of bash.


### PR DESCRIPTION
When running in non-interactive environments sometimes the TERM is set to 'unknown' rather than being unset, e.g. https://askubuntu.com/questions/1091553/how-do-i-fix-error-opening-terminal-unknown-on-ubuntu-server

It's surprisingly hard to manufacture a situation where this occurs (I've been trying for the past 30mn, but my tools seem too clever for their own goods), but the issue was seen at least once in the Ubuntu test suite, which is why they carry a similar patch (see http://launchpadlibrarian.net/356118225/liquidprompt_1.11-3_1.11-3ubuntu1.diff.gz because I couldn't find a public link with the raw patch itself).

The failing tests: https://autopkgtest.ubuntu.com/results/autopkgtest-bionic/bionic/amd64/l/liquidprompt/20180206_154026_dc5c9@/log.gz