### PR TITLE
Add option LP_USE_SUDO_VALIDATE to change sudo credential testing

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -551,17 +551,7 @@ Features
       run ``sudo`` once each prompt. This is likely to make your sysadmin hate
       you.
 
-   See also: :attr:`LP_COLOR_MARK_SUDO`, :attr:`LP_USE_SUDO_VALIDATE`.
-
-.. attribute:: LP_USE_SUDO_VALIDATE
-   :type: bool
-   :value: 0
-
-   Use sudo validate command ``sudo -v`` to check for valid credentials.
-
-   :attr:`LP_ENABLE_SUDO` must be enabled for this to have any effect.
-
-   See also: :attr:`LP_ENABLE_SUDO`.
+   See also: :attr:`LP_COLOR_MARK_SUDO`.
 
 .. attribute:: LP_ENABLE_SVN
    :type: bool

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -551,7 +551,17 @@ Features
       run ``sudo`` once each prompt. This is likely to make your sysadmin hate
       you.
 
-   See also: :attr:`LP_COLOR_MARK_SUDO`.
+   See also: :attr:`LP_COLOR_MARK_SUDO`, :attr:`LP_USE_SUDO_VALIDATE`.
+
+.. attribute:: LP_USE_SUDO_VALIDATE
+   :type: bool
+   :value: 0
+
+   Use sudo validate command ``sudo -v`` to check for valid credentials.
+
+   :attr:`LP_ENABLE_SUDO` must be enabled for this to have any effect.
+
+   See also: :attr:`LP_ENABLE_SUDO`.
 
 .. attribute:: LP_ENABLE_SVN
    :type: bool

--- a/liquidprompt
+++ b/liquidprompt
@@ -251,6 +251,7 @@ __lp_source_config() {
     LP_ENABLE_FQDN=${LP_ENABLE_FQDN:-0}
     LP_DISABLED_VCS_PATHS=( ${LP_DISABLED_VCS_PATHS[@]+"${LP_DISABLED_VCS_PATHS[@]}"} )
     LP_ENABLE_SUDO=${LP_ENABLE_SUDO:-0}
+    LP_USE_SUDO_VALIDATE=${LP_USE_SUDO_VALIDATE:-0}
     LP_ENABLE_COLOR=${LP_ENABLE_COLOR:-1}
     LP_ENABLE_ERROR=${LP_ENABLE_ERROR:-1}
     LP_ENABLE_DIRSTACK=${LP_ENABLE_DIRSTACK:-0}
@@ -1331,9 +1332,14 @@ _lp_username_color() {
 # Test the code with the commands:
 #   sudo id   # sudo, enter your credentials
 #   sudo -K   # revoke your credentials
+#   sudo -v   # return non-zero when no credentials are cached
 _lp_sudo_active() {
     (( LP_ENABLE_SUDO )) || return 2
-    \sudo -n true 2>/dev/null || return 1
+    if (( LP_USE_SUDO_VALIDATE )); then
+        \sudo -nv 2>/dev/null || return 1
+    else
+        \sudo -n true 2>/dev/null || return 1
+    fi
 }
 
 _lp_sudo_active_color() {

--- a/liquidprompt
+++ b/liquidprompt
@@ -251,7 +251,6 @@ __lp_source_config() {
     LP_ENABLE_FQDN=${LP_ENABLE_FQDN:-0}
     LP_DISABLED_VCS_PATHS=( ${LP_DISABLED_VCS_PATHS[@]+"${LP_DISABLED_VCS_PATHS[@]}"} )
     LP_ENABLE_SUDO=${LP_ENABLE_SUDO:-0}
-    LP_USE_SUDO_VALIDATE=${LP_USE_SUDO_VALIDATE:-0}
     LP_ENABLE_COLOR=${LP_ENABLE_COLOR:-1}
     LP_ENABLE_ERROR=${LP_ENABLE_ERROR:-1}
     LP_ENABLE_DIRSTACK=${LP_ENABLE_DIRSTACK:-0}
@@ -1335,11 +1334,7 @@ _lp_username_color() {
 #   sudo -v   # return non-zero when no credentials are cached
 _lp_sudo_active() {
     (( LP_ENABLE_SUDO )) || return 2
-    if (( LP_USE_SUDO_VALIDATE )); then
-        \sudo -nv 2>/dev/null || return 1
-    else
-        \sudo -n true 2>/dev/null || return 1
-    fi
+    \sudo -nv 2>/dev/null || return 1
 }
 
 _lp_sudo_active_color() {


### PR DESCRIPTION
Validation of sudo credentials is done by invoking a command (true).

This means that, if the user has sudo credentials, a root session is opened and then closed. Potentially generating two PAM messages plus the sudo line for true being executed as root:
```
sudo:     user : TTY=pts/4 ; PWD=/home/user/Projects/liquidprompt ; USER=root ; COMMAND=/usr/bin/true
sudo: pam_unix(sudo:session): session opened for user root(uid=0) by user(uid=1000)
sudo: pam_unix(sudo:session): session closed for user root
```
This makes filtering this messages rather complex. Specially the pam ones that cannot be distinguished form other sudo commands.

This commit adds an option to use the _validate_ command (sudo -v) to test for credentials. The difference is that **_validate_ does not generate any log on success**. ie. If the user has cached credentials.

In case the user does not have cached credentials, or not in sudoers, it  has the same behaviour as before: error line:
```
sudo:     user : a password is required ; TTY=pts/7 ; PWD=/home/user/Projects/liquidprompt; USER=root ; COMMAND=validate
sudo:     nobody : command not allowed ; TTY=pts/3 ; PWD=/home/user/Projects/liquidprompt ; USER=root ; COMMAND=validate
```
However, this lines are easy to filter out by searching COMMAND=validate

I've opted for adding LP_USE_SUDO_VALIDATE instead of replacing the default behaviour because I'm not sure if -v is on every system. 
The default value is 0: using the old behaviour.