### PR TITLE
feat(utils): adds the lp_fill function

### DIFF
--- a/docs/functions/util.rst
+++ b/docs/functions/util.rst
@@ -26,6 +26,41 @@ These functions are designed to be used by themes.
 
    The returned string is a fully escaped terminal formatting sequence.
 
+.. function:: _lp_fill(left, right, [fillstring], [splitends]) -> var:lp_fill
+
+   Adds as much *fillstring* (e.g. spaces) between *left* and *right*,
+   so as to make the resulting string the same width as the current terminal.
+
+   If *fillstring* is omitted, it defaults to one space.
+
+   If *fillstring* is a string with several characters
+   and *splitends* is 1 (the default),
+   then the final occurrence of *fillstring*
+   will have its end cut, so as to fit the terminal width.
+
+   If *fillstring* has multiple characters and *splitends* is 0,
+   some spaces will be inserted after the last occurrence of *fillstring*,
+   so as to match the exact width of the terminal.
+
+   *fillstring* may contains escaped sequences (such as colors).
+
+   .. note:: If *fillstring* have multiple characters and *splitends* is 1,
+             then **the last occurrence** of *fillstring*
+             is stripped of any escaped sequences
+             and only its printable characters are inserted.
+
+   If the available number of columns in the terminal is smaller than
+   the width of *left* and *right* combined, then
+   the function will return code 1 and set *lp_fill* to
+   *left* and *right*, concatenated.
+
+   For example, ``_lp_fill "Left part·" "·right part" "⣀⠔⠉⠢" 1`` will render
+   (in a terminal being 32 characters large):
+
+      Left part·⣀⠔⠉⠢⣀⠔⠉⠢⣀⠔⠉·right part
+
+   .. versionadded:: 2.2
+
 .. function:: _lp_grep_fields(filename, delimiter, keys...) -> var:lp_grep_fields
 
    Parse the given filename for one key/value pairs of the form

--- a/liquidprompt
+++ b/liquidprompt
@@ -992,6 +992,68 @@ _lp_grep_fields() {
     done <"$file"
 }
 
+# Adds as much $3 character (e.g. spaces) between $1 and $2,
+# so as to make the resulting string the same width as the current terminal.
+_lp_fill() {
+
+    local left="$1" right="$2" fillchars="${3:-" "}" splitends="${4:-1}"
+
+    # Compute the gap between left and right.
+    local ret
+    __lp_strip_escapes "$left"
+    local left_as_text="$ret"
+    __lp_strip_escapes "$right"
+    local right_as_text="$ret"
+    local gap_width=$((${COLUMNS:-80}-${#left_as_text}-${#right_as_text}))
+    if [[ $gap_width -lt 0 ]] ; then
+        lp_fill="${left}${right}"
+        return 1
+    fi
+
+    local filled=""
+    __lp_strip_escapes "$fillchars"
+    local fillchars_as_text="${ret}"
+    local fillchars_as_text_width=${#fillchars_as_text}
+    local nb_fillchars=$((gap_width/fillchars_as_text_width))
+    local i
+    for (( i=0; i < nb_fillchars; i++ )) ; do
+        filled+="$fillchars"
+    done
+
+    __lp_strip_escapes "$filled"
+    local actual_width=${#ret}
+    # If there is still a gap (i.e. we have an unaligned multi-character fillchars).
+    if [[ ${actual_width} -lt ${gap_width} ]] ; then
+        # User asked for splitends.
+        if [[ $splitends -ne 0 ]] ; then
+            # The last occurence is necessarily stripped from escaped sequences,
+            # or else we may have dangling sequences.
+            for (( i=_LP_FIRST_INDEX; i < $((${#fillchars_as_text}+_LP_FIRST_INDEX)); i++ )) ; do
+                # Get one single character.
+                if (( _LP_SHELL_zsh )) ; then
+                    filled+="${fillchars_as_text[i,i]}"
+                else
+                    filled+="${fillchars_as_text:i:1}"
+                fi
+                __lp_strip_escapes "$filled"
+                actual_width=${#ret}
+                if [[ ${actual_width} -ge ${gap_width} ]] ; then
+                    # Stop at this char if we're full.
+                    break
+                fi
+            done
+        else # User asked for no splitends.
+            for (( i=actual_width; i < gap_width; i++ )) ; do
+                # Fill with spaces.
+                filled+=" "
+            done
+        fi
+    fi
+
+    # shellcheck disable=SC2034
+    lp_fill="${left}${filled}${right}"
+}
+
 
 ##########################
 # Working Directory Path #

--- a/tests/test_utils.sh
+++ b/tests/test_utils.sh
@@ -694,6 +694,70 @@ function test_path_format_last_dir() {
   assertEquals "full directory formatting with multichar separator" "{l}pathname" "$lp_path_format"
 }
 
+function test_lp_fill {
+    local lp_fill
+
+    COLUMNS=80
+    _lp_fill "Left" "Right" " "
+    assertEquals "full width" 80 ${#lp_fill}
+
+    COLUMNS=3
+    _lp_fill "L" "R" "-"
+    assertEquals "single fill" "L-R" "$lp_fill"
+
+    _lp_fill "L" "R" ""
+    assertEquals "defaults to space" "L R" "$lp_fill"
+
+    COLUMNS=5
+    _lp_fill "L" "R" "~"
+    assertEquals "simple fill 5" "L~~~R" "$lp_fill"
+
+    COLUMNS=6
+    _lp_fill "L" "R" "+-"
+    assertEquals "multi-fill 6" "L+-+-R" "$lp_fill"
+
+    _lp_fill "L" "R" "123" 1
+    assertEquals "multi-fill 6 split" "L1231R" "$lp_fill"
+
+    _lp_fill "L" "R" "${_LP_OPEN_ESC}${_LP_CLOSE_ESC}123" 0
+    assertEquals "multi-fill 6 with escape and no split" "L${_LP_OPEN_ESC}${_LP_CLOSE_ESC}123 R" "$lp_fill"
+
+    _lp_fill "L" "R" "${_LP_OPEN_ESC}${_LP_CLOSE_ESC}123" 1
+    assertEquals "multi-fill 6 with escape and split" "L${_LP_OPEN_ESC}${_LP_CLOSE_ESC}1231R" "$lp_fill"
+
+    COLUMNS=11
+    _lp_fill "Left" "Right" "="
+    assertEquals "regular fill 11" "Left==Right" "$lp_fill"
+
+    _lp_fill "Le" "Ri" "+-"
+    assertEquals "multi-fill 11 split default" "Le+-+-+-+Ri" "$lp_fill"
+
+    _lp_fill "Le" "Ri" "+-" 0
+    assertEquals "multi-fill 11 no split" "Le+-+-+- Ri" "$lp_fill"
+
+    _lp_fill "Le" "Ri" "+-" 1
+    assertEquals "multi-fill 11 explicit split" "Le+-+-+-+Ri" "$lp_fill"
+
+    _lp_fill "Le" "Ri" "123" 1
+    assertEquals "multi-fill 11 with split" "Le1231231Ri" "$lp_fill"
+
+    _lp_fill "Le" "Ri" "${_LP_OPEN_ESC}${_LP_CLOSE_ESC}123" 0
+    assertEquals "multi-fill 11 with escape and no split" "Le${_LP_OPEN_ESC}${_LP_CLOSE_ESC}123${_LP_OPEN_ESC}${_LP_CLOSE_ESC}123 Ri" "$lp_fill"
+
+    _lp_fill "Le" "Ri" "${_LP_OPEN_ESC}${_LP_CLOSE_ESC}123" 1
+    assertEquals "multi-fill 11 with escape and split" "Le${_LP_OPEN_ESC}${_LP_CLOSE_ESC}123${_LP_OPEN_ESC}${_LP_CLOSE_ESC}1231Ri" "$lp_fill"
+
+    # The Windows runners have issues with these Unicode characters.
+    if [[ ${RUNNER_OS-} == "Windows" ]]; then
+        # Skip all the following tests.
+        startSkipping
+    fi
+
+    COLUMNS=32
+    _lp_fill "Left part·" "·right part" "⣀⠔⠉⠢" 1
+    assertEquals "beautiful fill" "Left part·⣀⠔⠉⠢⣀⠔⠉⠢⣀⠔⠉·right part" "$lp_fill"
+}
+
 function test_is_function {
   function my_function { :; }
 


### PR DESCRIPTION
Simulate right-aligned string part by filling the line.

(Extracted from the former DotMatrix PR)