### PR TITLE
fix(mux): typo in returned variable of _lp_multiplexer

### DIFF
--- a/docs/functions/data.rst
+++ b/docs/functions/data.rst
@@ -240,7 +240,7 @@ Environment
 
    .. versionadded:: 2.0
 
-.. function:: _lp_multiplexer() -> var:lp_mulitplexer
+.. function:: _lp_multiplexer() -> var:lp_multiplexer
 
    Returns ``true`` if the current shell context is inside a terminal
    multiplexer. Returns a string matching the multiplexer:

--- a/liquidprompt
+++ b/liquidprompt
@@ -1261,10 +1261,10 @@ _lp_error_color() {
 # shellcheck disable=SC2034
 _lp_multiplexer() {
     if [[ -n ${TMUX-} ]]; then
-        lp_mulitplexer=tmux
+        lp_multiplexer=tmux
         return 0
     elif [[ "${TERM-}" == screen* ]]; then
-        lp_mulitplexer=screen
+        lp_multiplexer=screen
         return 0
     fi
     return 1


### PR DESCRIPTION
Just two characters changed.