### PR TITLE
feat(contributing): move PR checklist in a Github template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,6 +96,33 @@ for our standards on shell language.
     # Create the pull request on GitHub. Check that Github chose the `master`
     # branch as the starting point for your branch.
 
+### Technical checklist for adding a new prompt section
+
+Here is a list of technical details that will be checked when making any
+code change:
+
+- code follows our [shell standards](https://github.com/nojhan/liquidprompt/wiki/Shell-standards):
+    - [ ] correct use of `IFS`
+    - [ ] careful quoting
+    - [ ] cautious array access
+    - [ ] portable array indexing with `_LP_FIRST_INDEX`
+    - [ ] functions/variable naming conventions
+    - [ ] functions have local variables
+    - [ ] data functions have optimization guards (early exits)
+    - [ ] subshells are avoided as much as possible
+- tests and checks have been added, ran, and their warnings fixed:
+    - [ ] unit tests have been updated (see `tests/test_*.sh` files)
+    - [ ] ran `test.sh`
+    - [ ] ran `shellcheck.sh` (requires [shellcheck](https://github.com/koalaman/shellcheck#user-content-installing)).
+- documentation have been updated accordingly:
+    - [ ] functions and attributes are documented in alphabetical order
+    - [ ] tag `.. versionadded:: X.Y` or `.. versionchanged:: Y.Z`
+    - [ ] functions signatures have arguments, returned code, and set value(s)
+    - [ ] attributes have types and defaults
+    - [ ] ran `docs/docs-lint.sh` (requires Python 3 and `requirements.txt`
+          installed (`cd docs/; python3 -m venv venv; . venv/bin/activate; pip install -r requirements.txt`))
+
+
 ### How do I make a good pull request?
 
 1. Check that your Git authorship settings are correct:
@@ -137,34 +164,6 @@ branch of the main repo, never, ever, *merge* the `master` branch into your own
 branch. Instead, always *rebase* your own work on top of the `master` branch.
 
 
-### Technical checklist for adding a new prompt section
-
-Here is a list of technical details that will be checked when making any
-code change:
-
-- code follows our [shell standards](https://github.com/nojhan/liquidprompt/wiki/Shell-standards):
-    - [ ] correct use of `IFS`
-    - [ ] careful quoting
-    - [ ] cautious array access
-    - [ ] portable array indexing with `_LP_FIRST_INDEX`
-    - [ ] functions/variable naming conventions
-    - [ ] functions have local variables
-    - [ ] data functions have optimization guards (early exits)
-    - [ ] subshells are avoided as much as possible
-- tests and checks have been added, ran, and their warnings fixed:
-    - [ ] unit tests have been updated (see `tests/test_*.sh` files)
-    - [ ] ran `test.sh`
-    - [ ] ran `shellcheck.sh` (requires [shellcheck](https://github.com/koalaman/shellcheck#user-content-installing)).
-- documentation have been updated accordingly:
-    - [ ] functions and attributes are documented in alphabetical order
-    - [ ] tag `.. versionadded:: X.Y` or `.. versionchanged:: Y.Z`
-    - [ ] functions signatures have arguments, returned code, and set value(s)
-    - [ ] attributes have types and defaults
-    - [ ] features disabled by defaults are listed in `overview.rst`
-    - [ ] ran `docs/docs-lint.sh` (requires Python 3 and `requirements.txt`
-          installed (`cd docs/; python3 -m venv venv; . venv/bin/activate; pip install -r requirements.txt`))
-
-
 ### Can I make a pull request without a separate issue for a bug/enhancement?
 Yes, **but**, in that case, the pull request **must have a full description of
 the bug or feature**. Just because you have fixed/implemented it already
@@ -177,8 +176,13 @@ Before being applied, your pull request will be reviewed by the maintainer
 and also by other users. You can also help the project by reviewing others
 pull requests.
 
+The reviewer will almost always ask for some changes.
+In that case, just push an additional commit implementing the requested changes,
+and then ask for a review update.
+At the end, the reviewer may ask you to "squash" all review commits in a single one.
+
 If your patch is accepted it will be applied either:
-- by "merging" your branch
+- by "merging" your branch,
 - by cherry-picking your commit on top of the `master` branch. This makes the
   history linear, and so easier to track.
 

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,33 @@
+
+<!-- Provide a description here -->
+
+<!-- Related issue: #XXX -->
+
+
+# Technical checklist:
+
+- code follows our [shell standards](https://github.com/nojhan/liquidprompt/wiki/Shell-standards):
+    - [ ] correct use of `IFS`
+    - [ ] careful quoting
+    - [ ] cautious array access
+    - [ ] portable array indexing with `_LP_FIRST_INDEX`
+    - [ ] printing a "%" character is done with `_LP_PERCENT`
+    - [ ] functions/variable naming conventions
+    - [ ] functions have local variables
+    - [ ] data functions have optimization guards (early exits)
+    - [ ] subshells are avoided as much as possible
+    - [ ] string substitutions may be done differently in Bash and Zsh (use `_LP_SHELL_*`)
+- tests and checks have been added, ran, and their warnings fixed:
+    - [ ] unit tests have been updated (see `tests/test_*.sh` files)
+    - [ ] ran `test.sh`
+    - [ ] ran `shellcheck.sh` (requires [shellcheck](https://github.com/koalaman/shellcheck#user-content-installing)).
+- documentation have been updated accordingly:
+    - [ ] functions and attributes are documented in alphabetical order
+    - [ ] new sections are documented in the default theme
+    - [ ] tag `.. versionadded:: X.Y` or `.. versionchanged:: Y.Z`
+    - [ ] functions signatures have arguments, returned code, and set value(s)
+    - [ ] attributes have types and defaults
+    - [ ] ran `docs/docs-lint.sh` (requires Python 3 and `requirements.txt`
+          installed (`cd docs/; python3 -m venv venv; . venv/bin/activate; pip install -r requirements.txt`))
+
+


### PR DESCRIPTION
This should allow contributors (read: me, in particular) to not forget essential steps in the PR.