### PR TITLE
feat(devenv): adds Modules support

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -608,6 +608,46 @@ Features
    See also: :attr:`LP_LOAD_THRESHOLD`, :attr:`LP_LOAD_CAP`,
    :attr:`LP_MARK_LOAD`, :attr:`LP_PERCENTS_ALWAYS`, and :attr:`LP_COLORMAP`.
 
+.. attribute:: LP_ENABLE_MODULES
+   :type: bool
+   :value: 1
+
+   Display the currently loaded `Modules <https://modules.readthedocs.io/>`_.
+
+   See also:
+   * :attr:`LP_ENABLE_MODULES_VERSIONS`,
+   * :attr:`LP_ENABLE_MODULES_HASHCOLOR`,
+   * :attr:`LP_COLOR_MODULES`,
+   * :attr:`LP_MARK_MODULES_OPEN`,
+   * :attr:`LP_MARK_MODULES_SEP`,
+   * :attr:`LP_MARK_MODULES_CLOSE`.
+
+   .. versionadded:: 2.2
+
+.. attribute:: LP_ENABLE_MODULES_VERSIONS
+   :type: bool
+   :value: 1
+
+   Display the currently loaded modules' versions, after their names
+   (separated by a slash, as in the ``module list`` command).
+
+   If disabled, only the name of the module is displayed.
+
+   See :attr:`LP_ENABLE_MODULES`.
+
+   .. versionadded:: 2.2
+
+.. attribute:: LP_ENABLE_MODULES_HASHCOLOR
+   :type: bool
+   :value: 0
+
+   If enabled, each item in the modules section will be randomly colored,
+   according to its hash, instead of using :attr:`LP_COLOR_MODULES`.
+
+   See :attr:`LP_ENABLE_MODULES`.
+
+   .. versionadded:: 2.2
+
 .. attribute:: LP_ENABLE_NODE_VENV
    :type: bool
    :value: 0
@@ -1345,6 +1385,30 @@ Marks
 
    See also: :attr:`LP_ENABLE_LOAD`.
 
+.. attribute:: LP_MARK_MODULES_OPEN
+   :type: string
+   :value: ""
+
+   Mark used before displaying loaded modules.
+
+   See also: :attr:`LP_ENABLE_MODULES`.
+
+.. attribute:: LP_MARK_MODULES_CLOSE
+   :type: string
+   :value: ""
+
+   Mark used after displaying loaded modules.
+
+   See also: :attr:`LP_ENABLE_MODULES`.
+
+.. attribute:: LP_MARK_MODULES_SEP
+   :type: string
+   :value: ":"
+
+   Mark used between loaded modules.
+
+   See also: :attr:`LP_ENABLE_MODULES`.
+
 .. attribute:: LP_MARK_MULTIPLEXER_CLOSE
    :type: string
    :value: $LP_MARK_BRACKET_CLOSE
@@ -1816,6 +1880,15 @@ Valid preset color variables are:
    of :attr:`LP_COLOR_MARK`.
 
    See also: :attr:`LP_ENABLE_SUDO`.
+
+.. attribute:: LP_COLOR_MODULES
+   :type: string
+   :value: $BLUE
+
+   Color used for displaying currently loaded modules
+   (if :attr:`LP_ENABLE_MODULES_HASHCOLOR` is disabled).
+
+   See also: :attr:`LP_ENABLE_MODULES`.
 
 .. attribute:: LP_COLOR_NODE_VENV
    :type: string

--- a/liquidprompt
+++ b/liquidprompt
@@ -435,6 +435,9 @@ __lp_source_config() {
     LP_ENABLE_CONTAINER=${LP_ENABLE_CONTAINER:-0}
     LP_ENABLE_SCLS=${LP_ENABLE_SCLS:-1}
     LP_ENABLE_AWS_PROFILE=${LP_ENABLE_AWS_PROFILE:-1}
+    LP_ENABLE_MODULES=${LP_ENABLE_MODULES:-1}
+    LP_ENABLE_MODULES_VERSIONS=${LP_ENABLE_MODULES_VERSIONS:-1}
+    LP_ENABLE_MODULES_HASHCOLOR=${LP_ENABLE_MODULES_HASHCOLOR:-0}
     LP_ENABLE_VCS_ROOT=${LP_ENABLE_VCS_ROOT:-0}
     LP_ENABLE_TITLE=${LP_ENABLE_TITLE:-0}
     LP_ENABLE_SCREEN_TITLE=${LP_ENABLE_SCREEN_TITLE:-0}
@@ -491,6 +494,9 @@ __lp_source_config() {
     LP_MARK_DEV_OPEN="${LP_MARK_DEV_OPEN:-"<"}"
     LP_MARK_DEV_CLOSE="${LP_MARK_DEV_CLOSE:-">"}"
     LP_MARK_DEV_MID="${LP_MARK_DEV_MID:-"|"}"
+    LP_MARK_MODULES_OPEN="${LP_MARK_MODULES_OPEN:-""}"
+    LP_MARK_MODULES_SEP="${LP_MARK_MODULES_SEP:-":"}"
+    LP_MARK_MODULES_CLOSE="${LP_MARK_MODULES_CLOSE:-""}"
     LP_MARK_CMAKE="${LP_MARK_CMAKE:-":"}"
     LP_MARK_KUBECONTEXT=${LP_MARK_KUBECONTEXT:-"⎈"}
     LP_MARK_JOBS_SEPARATOR="${LP_MARK_JOBS_SEPARATOR:-"/"}"
@@ -550,6 +556,7 @@ __lp_source_config() {
     LP_COLOR_DIRSTACK=${LP_COLOR_DIRSTACK:-$BOLD_YELLOW}
     LP_COLOR_KUBECONTEXT=${LP_COLOR_KUBECONTEXT:-$CYAN}
     LP_COLOR_AWS_PROFILE=${LP_COLOR_AWS_PROFILE:-$YELLOW}
+    LP_COLOR_MODULES=${LP_COLOR_MODULES:-$BLUE}
     LP_COLOR_SHLVL=${LP_COLOR_SHLVL:-$BOLD_GREEN}
 
     LP_COLORMAP=( ${LP_COLORMAP[@]+"${LP_COLORMAP[@]}"} )
@@ -2133,6 +2140,60 @@ _lp_cmake_color() {
             _lp_hash_color "$lp_cmake_buildtype"
             lp_cmake_color+="$lp_hash_color"
         fi
+    fi
+}
+
+_lp_modules() {
+    (( LP_ENABLE_MODULES )) || return 2
+    lp_modules=()
+    # # Module sets the LOADEDMODULES environment variable.
+    if [[ -n "${LOADEDMODULES-}" ]]; then
+        # Outer test should be faster.
+        if (( LP_ENABLE_MODULES_VERSIONS )); then
+            local IFS=':'
+            for mod in $LOADEDMODULES; do
+                lp_modules+=("${mod}")
+            done
+        else
+            local IFS=':'
+            for mod in $LOADEDMODULES; do
+                # Simply remove the part after the slash.
+                # Should work on both Bash and Zsh.
+                lp_modules+=("${mod%/*}")
+            done
+        fi
+        if (( ${#lp_modules[@]} == 0 )); then
+            return 1
+        fi
+    else
+        return 1
+    fi
+}
+
+_lp_modules_color() {
+    lp_modules_color=
+    if _lp_modules; then
+        if (( LP_ENABLE_COLOR )); then
+            local lp_join
+            if (( LP_ENABLE_MODULES_HASHCOLOR )); then
+                local modules=()
+                for mod in "${lp_modules[@]}"; do
+                    _lp_hash_color "${mod}"
+                    modules+=("${lp_hash_color}")
+                done
+                # Do not color marks and separators.
+                _lp_join "${NO_COL}${LP_MARK_MODULES_SEP}" "${modules[@]}"
+                lp_modules_color="${LP_MARK_MODULES_OPEN}${lp_join}${NO_COL}${LP_MARK_MODULES_CLOSE}"
+            else # No hashcolor.
+                _lp_join "${NO_COL}${LP_MARK_MODULES_SEP}${LP_COLOR_MODULES}" "${lp_modules[@]}"
+                lp_modules_color="${LP_MARK_MODULES_OPEN}${LP_COLOR_MODULES}${lp_join}${NO_COL}${LP_MARK_MODULES_CLOSE}"
+            fi
+        else # No color.
+            _lp_join "${LP_MARK_MODULES_SEP}" "${lp_modules[@]}"
+            lp_modules_color="${LP_MARK_MODULES_OPEN}${lp_join}${LP_MARK_MODULES_CLOSE}"
+        fi
+    else
+        return "$?"
     fi
 }
 
@@ -3942,6 +4003,7 @@ _lp_dev_env_color() {
     # add development environments
     local -a dev_all
     dev_all=(
+        "${lp_modules_color-}"
         "${lp_software_collections_color-}"
         "${lp_aws_profile_color-}"
         "${lp_container_color-}"
@@ -4165,6 +4227,12 @@ _lp_default_theme_prompt_data() {
         LP_OPSYS=" $lp_os_color"
     else
         LP_OPSYS=
+    fi
+
+    if _lp_modules_color; then
+        LP_MODULES=" $lp_modules_color"
+    else
+        LP_MODULES=
     fi
 
     # End of the section for dev-related variables.

--- a/tests/test_env.sh
+++ b/tests/test_env.sh
@@ -61,6 +61,38 @@ function test_env_vars {
     assertEquals "$?" "1"
 }
 
+function test_modules {
+
+    LP_ENABLE_MODULES=1
+    LP_ENABLE_MODULES_VERSIONS=1
+    LP_MARK_MODULES_OPEN="<"
+    LP_MARK_MODULES_CLOSE=">"
+    LP_MARK_MODULES_SEP="|"
+    LP_ENABLE_COLOR=0
+
+    LOADEDMODULES="trololo/1.2.3:tralala/0:trylyly/4.5.6.7-pre-alpha-turbo"
+
+    _lp_modules_color
+    assertEquals "<trololo/1.2.3|tralala/0|trylyly/4.5.6.7-pre-alpha-turbo>" "$lp_modules_color"
+
+    LP_ENABLE_MODULES_VERSIONS=0
+    _lp_modules_color
+    assertEquals "<trololo|tralala|trylyly>" "$lp_modules_color"
+
+    LOADEDMODULES="trilili/1.2.3.4"
+    _lp_modules_color
+    assertEquals "<trilili>" "$lp_modules_color"
+
+    LP_ENABLE_MODULES_VERSIONS=1
+    LOADEDMODULES="trululu/1"
+    _lp_modules_color
+    assertEquals "<trululu/1>" "$lp_modules_color"
+
+    LOADEDMODULES=""
+    _lp_modules_color
+    assertEquals "" "$lp_modules_color"
+}
+
 if [ -n "${ZSH_VERSION-}" ]; then
   SHUNIT_PARENT="$0"
   setopt shwordsplit


### PR DESCRIPTION
This feature will display the list of loaded modules in the "dev env" section.

Configurable information: items versions, color, hashed color, marks.

Environment modules is a tool allowing for dynamic modification of a user's environment, which is quite ubiquitous in high-performance computing systems. https://modules.readthedocs.io

Refs: #763


# Technical checklist:

- code follows our [shell standards](https://github.com/nojhan/liquidprompt/wiki/Shell-standards):
    - [x] correct use of `IFS`
    - [x] careful quoting
    - [x] cautious array access
    - [x] portable array indexing with `_LP_FIRST_INDEX`
    - [x] printing a "%" character is done with `_LP_PERCENT`
    - [x] functions/variable naming conventions
    - [x] functions have local variables
    - [x] data functions have optimization guards (early exits)
    - [x] subshells are avoided as much as possible
    - [x] string substitutions may be done differently in Bash and Zsh (use `_LP_SHELL_*`)
- tests and checks have been added, ran, and their warnings fixed:
    - [x] unit tests have been updated (see `tests/test_*.sh` files)
    - [x] ran `test.sh`
    - [x] ran `shellcheck.sh` (requires [shellcheck](https://github.com/koalaman/shellcheck#user-content-installing)).
- documentation have been updated accordingly:
    - [x] functions and attributes are documented in alphabetical order
    - [x] new sections are documented in the default theme
    - [x] tag `.. versionadded:: X.Y` or `.. versionchanged:: Y.Z`
    - [x] functions signatures have arguments, returned code, and set value(s)
    - [x] attributes have types and defaults
    - [x] ran `docs/docs-lint.sh` (requires Python 3 and `requirements.txt`
          installed (`cd docs/; python3 -m venv venv; . venv/bin/activate; pip install -r requirements.txt`))


