### PR TITLE
feat: adds a RAM sensor

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -827,6 +827,33 @@ Features
 
    See also: :attr:`LP_COLOR_PROXY`.
 
+.. attribute:: LP_ENABLE_RAM
+   :type: bool
+   :value: 1
+
+   Display a :attr:`LP_MARK_RAM` mark when the available amount of
+   Random Access Memory goes below a threshold.
+
+   Thresholds can be stated either:
+
+   * as a percentage with :attr:`LP_RAM_THRESHOLD_PERC`,
+   * or an absolute number *of kilobytes* with :attr:`LP_RAM_THRESHOLD`.
+
+   Display will occur if one of the thresholds is met.
+
+   If :attr:`LP_ALWAYS_DISPLAY_VALUES` is enabled, the prompt will show the
+   available space along with :attr:`LP_MARK_RAM`, if disabled, it will show
+   only the mark.
+
+   The precision of the displayed available space can be configured with
+   :attr:`LP_RAM_PRECISION`.
+
+   If :attr:`LP_DISPLAY_VALUES_AS_PERCENTS` is enabled, it will show the
+   percentage, if it is disabled, it will show the absolute value in a
+   human-readable form (i.e. with metric prefixed units).
+
+   .. versionadded:: 2.2
+
 .. attribute:: LP_ENABLE_RUBY_VENV
    :type: bool
    :value: 1
@@ -1245,6 +1272,46 @@ Thresholds
       Integer values of :spelling:word:`centiload` are still accepted, but
       deprecated.
 
+.. attribute:: LP_RAM_PRECISION
+   :type: int
+   :value: 2
+
+   Control the numbers of decimals when displaying the absolute available space
+   of the current system RAM. If set to 0, don't display decimals. If set to 1
+   or 2, display decimals.
+
+   See :attr:`LP_ENABLE_RAM`, :attr:`LP_ALWAYS_DISPLAY_VALUES`, and
+   :attr:`LP_DISPLAY_VALUES_AS_PERCENTS`.
+
+   .. versionadded:: 2.2
+
+.. attribute:: LP_RAM_THRESHOLD
+   :type: int
+   :value: 100000
+
+   Display something if the available RAM space goes below this absolute
+   threshold *in kilobytes*.
+
+   The threshold for RAM can also be set with :attr:`LP_RAM_THRESHOLD_PERC`,
+   the first one to be reached triggering the display.
+
+   See also :attr:`LP_ENABLE_RAM`.
+
+   .. versionadded:: 2.2
+
+.. attribute:: LP_RAM_THRESHOLD_PERC
+   :type: int
+   :value: 10
+
+   Display something if the available RAM space goes below this percentage.
+
+   The threshold for RAM can also be set with :attr:`LP_RAM_THRESHOLD`,
+   the first one to be reached triggering the display..
+
+   See also :attr:`LP_ENABLE_RAM`.
+
+   .. versionadded:: 2.2
+
 .. attribute:: LP_RUNTIME_THRESHOLD
    :type: int
    :value: 2
@@ -1642,6 +1709,15 @@ Marks
 
    See also: :attr:`LP_ENABLE_PROXY`.
 
+.. attribute:: LP_MARK_RAM
+   :type: string
+   :value: M
+
+   Mark used before displaying available Random Access Memory.
+   See :attr:`LP_ENABLE_RAM`.
+
+   .. versionadded:: 2.2
+
 .. attribute:: LP_MARK_SHLVL
    :type: string
    :value: "└"
@@ -1929,7 +2005,7 @@ Valid preset color variables are:
    :type: string
    :value: $RED
 
-   Color used for displaying the unit of the used space on the hard drive
+   Color used for displaying the unit of the available space on the hard drive
    hosting the current directory.
 
    See also :attr:`LP_COLOR_DISK`, :attr:`LP_ENABLE_DISK`,
@@ -2192,6 +2268,28 @@ Valid preset color variables are:
    Color used for :attr:`LP_MARK_PROXY`.
 
    See also: :attr:`LP_ENABLE_PROXY`.
+
+.. attribute:: LP_COLOR_RAM
+   :type: string
+   :value: $BOLD_RED
+
+   Color used for displaying information about the available RAM.
+
+   See also :attr:`LP_COLOR_RAM_UNITS`, :attr:`LP_ENABLE_RAM`,
+   :attr:`LP_ALWAYS_DISPLAY_VALUES`, and :attr:`LP_PERCENTS_ALWAYS`.
+
+   .. versionadded:: 2.2
+
+.. attribute:: LP_COLOR_RAM_UNITS
+   :type: string
+   :value: $RED
+
+   Color used for displaying the unit of the available RAM.
+
+   See also :attr:`LP_COLOR_RAM`, :attr:`LP_ENABLE_RAM`,
+   :attr:`LP_ALWAYS_DISPLAY_VALUES`, and :attr:`LP_PERCENTS_ALWAYS`.
+
+   .. versionadded:: 2.2
 
 .. attribute:: LP_COLOR_RUBY_VENV
    :type: string

--- a/docs/functions/data.rst
+++ b/docs/functions/data.rst
@@ -148,10 +148,10 @@ Disks and Memory
    Gather information about the current state of the hard drive hosting the
    *current directory*:
 
-   * occupied space in kibi-bytes (``lp_disk``, that is, 1024 bytes),
-   * occupied space in human-readable form, using binary unit prefixes
+   * available space in kibi-bytes (``lp_disk``, that is, 1024 bytes),
+   * available space in human-readable form, using binary unit prefixes
      (``lp_disk_human``, see also :func:`__lp_bytes_to_human`).
-   * occupied space as a percentage of total (``lp_disk_perc``).
+   * available space as a percentage of total (``lp_disk_perc``).
 
    Returns ``true`` if the used space is below at least one of the user-defined
    thresholds:
@@ -163,6 +163,24 @@ Disks and Memory
 
    .. versionadded:: 2.2
 
+.. function:: _lp_ram -> var:lp_ram, var:lp_ram_human, var:lp_ram_perc
+
+   Gather information about the current state of the RAM:
+
+   * available space in kibi-bytes (``lp_ram``, that is, 1024 bytes),
+   * available space in human-readable form, using binary unit prefixes
+     (``lp_ram_human``, see also :func:`__lp_bytes_to_human`).
+   * available space as a percentage of total (``lp_ram_perc``).
+
+   Returns ``true`` if the used space is below at least one of the user-defined
+   thresholds:
+
+   * :attr:`LP_RAM_THRESHOLD`
+   * :attr:`LP_RAM_THRESHOLD_PERC`
+
+   Can be disabled by :attr:`LP_ENABLE_RAM`.
+
+   .. versionadded:: 2.2
 
 
 Environment

--- a/docs/functions/theme.rst
+++ b/docs/functions/theme.rst
@@ -178,7 +178,7 @@ specific text and formatting may change.
 
 .. function:: _lp_disk_color() -> var:lp_disk_color
 
-   Returns information about occupied space of the hard drive hosting the
+   Returns information about available space of the hard drive hosting the
    current directory.
 
    If :attr:`LP_ALWAYS_DISPLAY_VALUES` is ``false``, displays a colored mark
@@ -321,6 +321,23 @@ specific text and formatting may change.
       No longer include squared brackets, superseded by
       :attr:`LP_MARK_DEV_OPEN`, :attr:`LP_MARK_DEV_MID` and
       :attr:`LP_MARK_DEV_CLOSE`.
+
+.. function:: _lp_ram_color() -> var:lp_ram_color
+
+   Returns information about available RAM.
+
+   If :attr:`LP_ALWAYS_DISPLAY_VALUES` is ``false``, displays a colored mark
+   (using :attr:`LP_MARK_RAM`), if the available ram goes below
+   :attr:`LP_RAM_THRESHOLD` or :attr:`LP_RAM_THRESHOLD_PERC`.
+   If it is ``true``, displays the corresponding value, either as a percentage
+   (if :attr:`LP_DISPLAY_VALUES_AS_PERCENTS` is ``true``) or as a
+   human-readable quantity (if :attr:`LP_DISPLAY_VALUES_AS_PERCENTS` is
+   ``false``).
+
+   The mark and the value itself are colored with :attr:`LP_COLOR_RAM`, while
+   the unit is colored with :attr:`LP_COLOR_RAM_UNITS`.
+
+   .. versionadded:: 2.2
 
 .. function:: _lp_ruby_env_color() -> var:lp_ruby_env_color
 

--- a/liquidprompt
+++ b/liquidprompt
@@ -391,6 +391,9 @@ __lp_source_config() {
     LP_DISK_THRESHOLD=${LP_DISK_THRESHOLD:-102400} # 100 MiB in KiB
     LP_DISK_THRESHOLD_PERC=${LP_DISK_THRESHOLD_PERC:-10} # 10% or less
     LP_DISK_PRECISION=${LP_DISK_PRECISION:-2}
+    LP_RAM_THRESHOLD=${LP_RAM_THRESHOLD:-102400} # 100 MiB in KiB
+    LP_RAM_THRESHOLD_PERC=${LP_RAM_THRESHOLD_PERC:-10} # 10% or less
+    LP_RAM_PRECISION=${LP_RAM_PRECISION:-2}
     LP_LOAD_THRESHOLD=${LP_LOAD_THRESHOLD:-0.60}
     LP_LOAD_CAP=${LP_LOAD_CAP:-2.0}
     LP_TEMP_THRESHOLD=${LP_TEMP_THRESHOLD:-60}
@@ -423,6 +426,7 @@ __lp_source_config() {
     LP_ENABLE_DETACHED_SESSIONS=${LP_ENABLE_DETACHED_SESSIONS:-1}
     LP_ENABLE_LOAD=${LP_ENABLE_LOAD:-1}
     LP_ENABLE_BATT=${LP_ENABLE_BATT:-1}
+    LP_ENABLE_RAM=${LP_ENABLE_RAM:-1}
     LP_ENABLE_DISK=${LP_ENABLE_DISK:-0}
     LP_ENABLE_GIT=${LP_ENABLE_GIT:-1}
     LP_ENABLE_SVN=${LP_ENABLE_SVN:-1}
@@ -512,6 +516,7 @@ __lp_source_config() {
     LP_MARK_OS_SEP=${LP_MARK_OS_SEP:-"/"}
     LP_MARK_OS=( ${LP_MARK_OS[@]+"${LP_MARK_OS[@]}"} )
     LP_MARK_DISK="${LP_MARK_DISK:-"🖴 "}"
+    LP_MARK_RAM="${LP_MARK_RAM:-"M"}"
 
     LP_COLOR_CMAKE_DEBUG=${LP_COLOR_CMAKE_DEBUG:-$MAGENTA}
     LP_COLOR_CMAKE_RWDI=${LP_COLOR_CMAKE_RWDI:-$BLUE}
@@ -570,6 +575,8 @@ __lp_source_config() {
     LP_COLOR_SHLVL=${LP_COLOR_SHLVL:-$BOLD_GREEN}
     LP_COLOR_DISK=${LP_COLOR_DISK:-$BOLD_RED}
     LP_COLOR_DISK_UNITS=${LP_COLOR_DISK_UNITS:-$RED}
+    LP_COLOR_RAM=${LP_COLOR_RAM:-$BOLD_RED}
+    LP_COLOR_RAM_UNITS=${LP_COLOR_RAM_UNITS:-$RED}
 
     LP_COLORMAP=( ${LP_COLORMAP[@]+"${LP_COLORMAP[@]}"} )
     if [[ ${#LP_COLORMAP[@]} == 0 ]]; then
@@ -591,6 +598,8 @@ __lp_source_config() {
     _LP_LINUX_POWERSUPPLY_PATH="/sys/class/power_supply"
     _LP_LINUX_WIRELESS_FILE="/proc/net/wireless"
     _LP_AIRPORT_BIN="/System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport"
+    _LP_LINUX_RAM_FILE="/proc/meminfo"
+    _LP_BSD_RAM_FILE="/var/run/dmesg.boot"
 
     if (( _LP_SHELL_zsh )); then
         setopt local_options nullglob
@@ -793,6 +802,7 @@ lp_activate() {
 
     if [[ "$LP_OS" = Darwin ]]; then
         _lp_require_tool BATT pmset
+        _lp_require_tool RAM vm_stat
     elif (( LP_ENABLE_BATT )); then
         __lp_battery_detect || LP_ENABLE_BATT=0
     fi
@@ -3759,6 +3769,148 @@ _lp_load_color() {
     lp_load_color+="$NO_COL"
 }
 
+#################
+# Available RAM #
+#################
+
+# Get RAM percentage.
+case "$LP_OS" in
+    Linux)
+        # Parse /proc/meminfo
+        __lp_ram_bytes() {
+            lp_ram_avail_bytes=
+            lp_ram_total_bytes=
+            local id value _
+            while IFS=$' \t' read -r id value _ ; do
+                if [[ $id == 'MemTotal:' ]]; then
+                    lp_ram_total_bytes=$value
+                elif [[ $id == 'MemAvailable:' ]]; then
+                    lp_ram_avail_bytes=$value
+                    # Note: this is the best conservative estimate from the kernel
+                    # of the memory than may be available for a process.
+                    # See https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=34e431b0ae398fc54ea69ff85ec700722c9da773
+                fi
+                if [[ -n "$lp_ram_total_bytes" && -n "$lp_ram_avail_bytes" ]]; then
+                    break
+                fi
+            # Assumes file exists.
+            done < "$_LP_LINUX_RAM_FILE"
+            # Used memory may be used in a theme.
+            # shellcheck disable=SC2034
+            lp_ram_used_bytes=$((lp_ram_total_bytes-lp_ram_avail_bytes))
+        }
+        ;;
+    FreeBSD|OpenBSD)
+        # Parse dmesg.boot
+        __lp_ram_bytes() {
+            lp_ram_avail_bytes=
+            lp_ram_total_bytes=
+            local first second _ value
+            while IFS=' ' read -r first second _ value _ _ ; do
+                if [[ $second == 'memory' ]]; then
+                    if [[ $first == 'usable' ]]; then
+                        lp_ram_total_bytes=$value
+                    elif [[ $first == 'avail' ]]; then
+                        lp_ram_avail_bytes=$value
+                    fi
+                fi
+                if [[ -n "$lp_ram_total_bytes" && -n "$lp_ram_avail_bytes" ]]; then
+                    break
+                fi
+            done < "$_LP_BSD_RAM_FILE"
+            # shellcheck disable=SC2034
+            lp_ram_used_bytes=$((lp_ram_total_bytes-lp_ram_avail_bytes))
+        }
+        ;;
+    Darwin)
+        # Parse vm_stat
+        __lp_ram_bytes() {
+            lp_ram_avail_bytes=0
+            lp_ram_total_bytes=0
+
+            # Call vm_stat.
+            local stat="$(vm_stat 2>/dev/null)"
+
+            # Read first line.
+            local page_size _ second third fourth fifth
+            IFS=' ' read -r _ _ _ _ _ _ _ page_size _ <<< "$stat"
+
+            # Read all other lines.
+            while IFS=' ' read -r _ second third fourth fifth ; do
+                case "$second" in
+                    free:)
+                        # Remove the last "." character.
+                        lp_ram_avail_bytes="${third:0:${#third}-1}"
+                        ;;
+                    active:|inactive:|speculative:|throttled:)
+                        lp_ram_total_bytes=$((lp_ram_total_bytes + ${third:0:${#third}-1}))
+                        ;;
+                    wired)
+                        lp_ram_total_bytes=$((lp_ram_total_bytes + ${fourth:0:${#fourth}-1}))
+                        ;;
+                    occupied)
+                        lp_ram_total_bytes=$((lp_ram_total_bytes + ${fifth:0:${#fifth}-1}))
+                        ;;
+                esac
+            done <<< "$stat"
+            lp_ram_avail_bytes=$((lp_ram_avail_bytes * page_size))
+            lp_ram_total_bytes=$(( lp_ram_avail_bytes + lp_ram_total_bytes * page_size))
+            # shellcheck disable=SC2034
+            lp_ram_used_bytes=$((lp_ram_total_bytes-lp_ram_avail_bytes))
+        }
+        ;;
+    *)
+        # Not implemented.
+        __lp_ram_bytes() {
+            return 5 # Same code as in _lp_battery.
+        }
+        ;;
+esac
+
+_lp_ram() {
+    (( LP_ENABLE_RAM )) || return 2
+
+    # Call the OS-specific function measuring RAM.
+    __lp_ram_bytes || return "$?"
+    # Now we have: lp_ram_avail_bytes, lp_ram_total_bytes, lp_ram_used_bytes.
+
+    lp_ram=
+    lp_ram_human=
+    lp_ram_perc=
+
+    lp_ram=$(( lp_ram_avail_bytes * 1024 )) # in KiB
+    lp_ram_perc=$(( 100 * lp_ram_avail_bytes / lp_ram_total_bytes ))
+
+    if (( lp_ram <= LP_RAM_THRESHOLD || lp_ram_perc <= LP_RAM_THRESHOLD_PERC )); then
+        local lp_bytes lp_bytes_units
+        __lp_bytes_to_human "${lp_ram}" "$LP_RAM_PRECISION"
+        lp_ram_human="${lp_bytes}"
+        lp_ram_human_units="${lp_bytes_units}"
+        return 0
+    else
+        return 1
+    fi
+}
+
+_lp_ram_color() {
+    if _lp_ram; then
+        if (( LP_ALWAYS_DISPLAY_VALUES )); then
+            if (( LP_DISPLAY_VALUES_AS_PERCENTS )); then
+                lp_ram_color="${LP_COLOR_RAM}${LP_MARK_RAM}${lp_ram_perc}${NO_COL}${LP_COLOR_RAM_UNITS}${_LP_PERCENT}${NO_COL}"
+            else
+                # Metric SI norms ask for a space, but we prefer to stay compact.
+                # Coloring value differently from unit helps readability.
+                # The mark should be different enough to not be a problem.
+                lp_ram_color="${LP_COLOR_RAM}${LP_MARK_RAM}${lp_ram_human}${NO_COL}${LP_COLOR_RAM_UNITS}${lp_ram_human_units}${NO_COL}"
+            fi
+        else
+            lp_ram_color="${LP_COLOR_RAM}${LP_MARK_RAM}${NO_COL}"
+        fi
+    else
+        return $?
+    fi
+}
+
 ######################
 # System temperature #
 ######################
@@ -4265,6 +4417,11 @@ _lp_default_theme_prompt_data() {
     else
         LP_WIFI=
     fi
+    if _lp_ram_color; then
+        LP_RAM="$lp_ram_color "
+    else
+        LP_RAM=
+    fi
     if _lp_disk_color; then
         LP_DISK="$lp_disk_color "
     else
@@ -4422,10 +4579,10 @@ _lp_default_theme_prompt_template() {
     fi
 
     if [[ -z "${LP_PS1-}" ]]; then
-        # add title escape time, jobs, load and battery
-        PS1="${LP_PS1_PREFIX}${LP_TIME}${LP_BATT}${LP_LOAD}${LP_TEMP}${LP_DISK}${LP_WIFI}${LP_JOBS}"
+        # Add title escape time, battery, load, temperature, RAM, disk, wifi, jobs.
+        PS1="${LP_PS1_PREFIX}${LP_TIME}${LP_BATT}${LP_LOAD}${LP_TEMP}${LP_RAM}${LP_DISK}${LP_WIFI}${LP_JOBS}"
 
-        # add user, host, permissions colon, working directory, and dirstack
+        # Add multiplexer brackets, user, host, permissions colon, working directory, dirstack, proxy, watched environment variables and nested shell level.
         PS1+="${LP_BRACKET_OPEN}${LP_USER}${LP_HOST}${LP_PERM}${LP_PWD}${LP_DIRSTACK}${LP_BRACKET_CLOSE}${LP_PROXY}${LP_ENVVARS}${LP_SHLVL}"
 
         # Add the list of development environments/config/etc.

--- a/tests/test_ram.sh
+++ b/tests/test_ram.sh
@@ -1,0 +1,229 @@
+
+# Error on unset variables
+set -u
+
+if [ -n "${ZSH_VERSION-}" ]; then
+  SHUNIT_PARENT="$0"
+  setopt shwordsplit ksh_arrays
+fi
+
+LP_ENABLE_RAM=1
+
+typeset -a os outputs values_avail values_total
+
+# Fake trivial Linux.
+# Should be the first one, for test_ram_threshold below.
+os+=('Linux')
+outputs+=('MemTotal: 2048 kB
+MemAvailable: 1024 kB')
+values_avail+=('1024')
+values_total+=('2048')
+
+# Linux 5.4.0-139-generic #156-Ubuntu SMP Fri Jan 20 17:27:18 UTC 2023 x86_64 x86_64 x86_64 GNU/Linux
+os+=('Linux')
+outputs+=('MemTotal:        8033668 kB
+MemFree:         2722348 kB
+MemAvailable:    6899116 kB
+Buffers:         1360936 kB
+Cached:          2226412 kB
+SwapCached:            0 kB
+Active:          2558628 kB
+Inactive:        1491516 kB
+Active(anon):     455688 kB
+Inactive(anon):    46872 kB
+Active(file):    2102940 kB
+Inactive(file):  1444644 kB
+Unevictable:        4504 kB
+Mlocked:              32 kB
+SwapTotal:       2097148 kB
+SwapFree:        2097148 kB
+Dirty:               336 kB
+Writeback:             0 kB
+AnonPages:        467004 kB
+Mapped:           451292 kB
+Shmem:             53164 kB
+KReclaimable:     939992 kB
+Slab:            1126700 kB
+SReclaimable:     939992 kB
+SUnreclaim:       186708 kB
+KernelStack:        5796 kB
+PageTables:         8952 kB
+NFS_Unstable:          0 kB
+Bounce:                0 kB
+WritebackTmp:          0 kB
+CommitLimit:     6113980 kB
+Committed_AS:    2605400 kB
+VmallocTotal:   34359738367 kB
+VmallocUsed:       71264 kB
+VmallocChunk:          0 kB
+Percpu:             4464 kB
+HardwareCorrupted:     0 kB
+AnonHugePages:         0 kB
+ShmemHugePages:        0 kB
+ShmemPmdMapped:        0 kB
+FileHugePages:         0 kB
+FilePmdMapped:         0 kB
+CmaTotal:              0 kB
+CmaFree:               0 kB
+HugePages_Total:       0
+HugePages_Free:        0
+HugePages_Rsvd:        0
+HugePages_Surp:        0
+Hugepagesize:       2048 kB
+Hugetlb:               0 kB
+DirectMap4k:      564428 kB
+DirectMap2M:     7710720 kB
+DirectMap1G:     1048576 kB
+'
+)
+values_avail+=('6899116')
+values_total+=('8033668')
+
+
+# (Free?)BSD, unknown version
+os+=('FreeBSD')
+outputs+=('usable memory = 34346901504 (32755 MB)
+avail memory  = 33139134464 (31603 MB)')
+values_avail+=('33139134464')
+values_total+=('34346901504')
+
+# Darwin 22.3.0 Darwin Kernel Version 22.3.0: Mon Jan 30 20:42:11 PST 2023; root:xnu-8792.81.3~2/RELEASE_X86_64 x86_64
+os+=('Darwin')
+outputs+=('Mach Virtual Memory Statistics: (page size of 4096 bytes)
+Pages free:                               77936.
+Pages active:                           1729321.
+Pages inactive:                         1684334.
+Pages speculative:                        45972.
+Pages throttled:                              0.
+Pages wired down:                        620324.
+Pages purgeable:                          18622.
+"Translation faults":                 134215056.
+Pages copy-on-write:                    2741383.
+Pages zero filled:                     97842470.
+Pages reactivated:                       658037.
+Pages purged:                            470473.
+File-backed pages:                       786795.
+Anonymous pages:                        2672832.
+Pages stored in compressor:              105679.
+Pages occupied by compressor:             35785.
+Decompressions:                          256471.
+Compressions:                            447621.
+Pageins:                                4513634.
+Pageouts:                                 11829.
+Swapins:                                   6144.
+Swapouts:                                  6656.
+')
+# free  * page_size
+# 77936 * 4096
+values_avail+=('319225856')
+# (free + active + inactive + speculative + throttled + wired down + occupied by compressor) * page_size
+# (77936+ 1729321+ 1684334  + 45972       + 0         + 620324     + 35785                 ) * 4096
+values_total+=('17177280512')
+
+
+function test_ram() {
+    _LP_LINUX_RAM_FILE="${SHUNIT_TMPDIR}/lpraminfo"
+    _LP_BSD_RAM_FILE="${SHUNIT_TMPDIR}/lpraminfo"
+    LP_RAM_THRESHOLD_PERC=100 # Available mem% will always lesser or equal than 100.
+    LP_RAM_THRESHOLD=$(( (1<<63)-1 )) # MAXINT in 64 bits.
+    LP_RAM_PRECISION=0
+    typeset lp_ram_avail_bytes lp_ram_total_bytes lp_ram_used_bytes
+    # Set to null because we don't use the `if _lp_ram` guard construction.
+    typeset lp_ram_used_perc= lp_ram_perc=
+
+    # Iterate over tests.
+    for (( i=0; i < ${#values_avail[@]}; i++ )); do
+        # Load Linux version.
+        uname() { printf "${os[$i]}"; }
+        . ../liquidprompt --no-activate
+        unset -f uname
+
+        # Linux and BSD.
+        printf '%s\n' "${outputs[$i]}" > "${SHUNIT_TMPDIR}/lpraminfo"
+        # Darwin.
+        vm_stat() {
+            printf '%s\n' "${outputs[$i]}"
+        }
+        __lp_ram_bytes
+        assertEquals "${LP_OS} available memory #$i." "${values_avail[$i]}" "${lp_ram_avail_bytes}"
+        assertEquals "${LP_OS} total memory #$i." "${values_total[$i]}" "${lp_ram_total_bytes}"
+        assertEquals "${LP_OS} used memory #$i." "$((lp_ram_total_bytes-lp_ram_avail_bytes))" "${lp_ram_used_bytes}"
+
+        _lp_ram
+        assertEquals "${LP_OS} untouched available memory #$i." "${values_avail[$i]}" "${lp_ram_avail_bytes}"
+        assertEquals "${LP_OS} untouched total memory #$i." "${values_total[$i]}" "${lp_ram_total_bytes}"
+        assertEquals "${LP_OS} untouched used memory #$i." "$((lp_ram_total_bytes-lp_ram_avail_bytes))" "${lp_ram_used_bytes}"
+        assertEquals "${LP_OS} available percentage #$i." "$((lp_ram_avail_bytes*100/lp_ram_total_bytes))" "${lp_ram_perc}"
+        # assertEquals "${LP_OS} used percentage #$i." "$((lp_ram_used_bytes*100/lp_ram_total_bytes))" "${lp_ram_used_perc}"
+    done
+    unset -f vm_stat
+}
+
+
+function test_ram_threshold()
+{
+    _LP_LINUX_RAM_FILE="${SHUNIT_TMPDIR}/lpraminfo"
+    LP_MARK_RAM="M"
+    LP_RAM_PRECISION=0
+    typeset lp_ram_perc=
+
+    # 0 = no error, 1 = error.
+    local OK=0 NO=1
+    local MAXINT=$(( (1<<63)-1 )) # MAXINT in 64 bits.
+
+    # Load Linux version.
+    uname() { printf 'Linux'; }
+    . ../liquidprompt --no-activate
+    unset -f uname
+
+    LP_RAM_THRESHOLD=0
+
+    # Fake trivial meminfo = 1024/2048 kB.
+    printf '%s\n' "${outputs[0]}" > "$_LP_LINUX_RAM_FILE"
+    LP_RAM_THRESHOLD_PERC=100
+    _lp_ram
+    assertEquals "Tests expect fake trivial meminfo" "50" "$lp_ram_perc"
+
+    LP_RAM_THRESHOLD_PERC=0
+    _lp_ram
+    assertEquals "No display at $lp_ram_perc <= $LP_RAM_THRESHOLD_PERC" "$NO" "$?"
+
+    LP_RAM_THRESHOLD_PERC=100
+    _lp_ram
+    assertEquals "Display at $lp_ram_perc <= $LP_RAM_THRESHOLD_PERC" "$OK" "$?"
+
+    LP_RAM_THRESHOLD_PERC=50
+    _lp_ram
+    assertEquals "Display at $lp_ram_perc <= $LP_RAM_THRESHOLD_PERC" "$OK" "$?"
+
+    LP_RAM_THRESHOLD_PERC=51
+    _lp_ram
+    assertEquals "Display at $lp_ram_perc <= $LP_RAM_THRESHOLD_PERC" "$OK" "$?"
+
+    LP_RAM_THRESHOLD_PERC=49
+    _lp_ram
+    assertEquals "No display at $lp_ram_perc <= $LP_RAM_THRESHOLD_PERC" "$NO" "$?"
+
+    # At least one or both thresholds.
+    LP_RAM_THRESHOLD_PERC=100
+    LP_RAM_THRESHOLD=0
+    _lp_ram
+    assertEquals "Display at $lp_ram_perc <= $LP_RAM_THRESHOLD_PERC" "$OK" "$?"
+
+    LP_RAM_THRESHOLD_PERC=0
+    LP_RAM_THRESHOLD=$MAXINT
+    _lp_ram
+    assertEquals "Display at $lp_ram_perc <= $LP_RAM_THRESHOLD_PERC" "$OK" "$?"
+
+    LP_RAM_THRESHOLD_PERC=100
+    LP_RAM_THRESHOLD=$MAXINT
+    _lp_ram
+    assertEquals "Display at $lp_ram_perc <= $LP_RAM_THRESHOLD_PERC" "$OK" "$?"
+
+    LP_RAM_THRESHOLD_PERC=0
+    LP_RAM_THRESHOLD=0
+    _lp_ram
+    assertEquals "No display at $lp_ram_perc <= $LP_RAM_THRESHOLD_PERC" "$NO" "$?"
+}
+
+. ./shunit2


### PR DESCRIPTION
Displays a (colored) mark (and a percentage) when the available of RAM goes below a threshold.

Refs: #52

# Technical checklist:

- code follows our [shell standards](https://github.com/nojhan/liquidprompt/wiki/Shell-standards):
    - [x] correct use of `IFS`
    - [x] careful quoting
    - [x] cautious array access
    - [x] portable array indexing with `_LP_FIRST_INDEX`
    - [x] printing a "%" character is done with `_LP_PERCENT`
    - [x] functions/variable naming conventions
    - [x] functions have local variables
    - [x] data functions have optimization guards (early exits)
    - [x] subshells are avoided as much as possible
    - [x] string substitutions may be done differently in Bash and Zsh (use `_LP_SHELL_*`)
- tests and checks have been added, ran, and their warnings fixed:
    - [x] unit tests have been updated (see `tests/test_*.sh` files)
    - [x] ran `test.sh`
    - [x] ran `shellcheck.sh` (requires [shellcheck](https://github.com/koalaman/shellcheck#user-content-installing)).
- documentation have been updated accordingly:
    - [x] functions and attributes are documented in alphabetical order
    - [x] new sections are documented in the default theme
    - [x] tag `.. versionadded:: X.Y` or `.. versionchanged:: Y.Z`
    - [x] functions signatures have arguments, returned code, and set value(s)
    - [x] attributes have types and defaults
    - [x] ran `docs/docs-lint.sh` (requires Python 3 and `requirements.txt`
          installed (`cd docs/; python3 -m venv venv; . venv/bin/activate; pip install -r requirements.txt`))
