### PR TITLE
Do not scan through all PIDs to find parent PID command

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -1641,7 +1641,7 @@ _lp_connection() {
         return
     fi
 
-    local sess_parent="$(ps -o comm= -p "$PPID" 2> /dev/null)"
+    local sess_parent="$(ps -o comm= -q "$PPID" 2> /dev/null)"
     if [[ "$sess_parent" = "su" || "$sess_parent" = "sudo" ]]; then
         lp_connection=su   # su/sudo
     else

--- a/tools/external-tool-tester.sh
+++ b/tools/external-tool-tester.sh
@@ -69,7 +69,7 @@ test_tool tput AB 0
 test_tool tput AB 0 0 0
 
 test_tool who am i
-test_tool ps -o comm= -p "$PPID"
+test_tool ps -o comm= -q "$PPID"
 test_tool logname
 
 test_tool screen -ls


### PR DESCRIPTION
There's one command that takes a long time after profiling bash startup. 
We currently scan though all processes just to find out $PPID command.
The time to do it grows linearly with a number of processes running.
Let's fix that.

Compare:
```bash
strace -e openat ps -o comm= -p $PPID
```
vs
```bash
strace -e openat ps -o comm= -q $PPID
```
# Technical checklist:

- code follows our [shell standards](https://github.com/liquidprompt/liquidprompt/wiki/Shell-standards):
    - [x] correct use of `IFS`
    - [x] careful quoting
    - [x] cautious array access
    - [x] portable array indexing with `_LP_FIRST_INDEX`
    - [x] printing a "%" character is done with `_LP_PERCENT`
    - [x] functions/variable naming conventions
    - [x] functions have local variables
    - [x] data functions have optimization guards (early exits)
    - [x] subshells are avoided as much as possible
    - [x] string substitutions may be done differently in Bash and Zsh (use `_LP_SHELL_*`)
- tests and checks have been added, ran, and their warnings fixed:
    - [x] unit tests have been updated (see `tests/test_*.sh` files)
    - [x] ran `tests.sh`
    - [x] ran `shellcheck.sh` (requires [shellcheck](https://github.com/koalaman/shellcheck#user-content-installing)).
- documentation have been updated accordingly:
    - [x] functions and attributes are documented in alphabetical order
    - [x] new sections are documented in the default theme
    - [x] tag `.. versionadded:: X.Y` or `.. versionchanged:: Y.Z`
    - [x] functions signatures have arguments, returned code, and set value(s)
    - [x] attributes have types and defaults
    - [x] ran `docs/docs-lint.sh` (requires Python 3 and `requirements.txt`
          installed (`cd docs/; python3 -m venv venv; . venv/bin/activate; pip install -r requirements.txt`))


