### PR TITLE
Adds an option to use only the current command in the terminal title

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1109,7 +1109,8 @@ Features
    Use only the currently running command for the terminal title while the
    command is running.
 
-   :attr:`LP_ENABLE_TITLE` must be enabled to have any effect.
+   :attr:`LP_ENABLE_TITLE` and :attr:`LP_ENABLE_TITLE_COMMAND` must be
+   enabled to have any effect.
 
    .. versionadded:: master
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1112,7 +1112,7 @@ Features
    :attr:`LP_ENABLE_TITLE` and :attr:`LP_ENABLE_TITLE_COMMAND` must be
    enabled to have any effect.
 
-   .. versionadded:: master
+   .. versionadded:: 2.3
 
 .. attribute:: LP_ENABLE_TMUX_TITLE_PANES
    :type: bool

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1102,6 +1102,17 @@ Features
 
    .. versionadded:: 2.1
 
+.. attribute:: LP_ENABLE_TITLE_COMMAND_ONLY
+   :type: bool
+   :value: 0
+
+   Use only the currently running command for the terminal title while the
+   command is running.
+
+   :attr:`LP_ENABLE_TITLE` must be enabled to have any effect.
+
+   .. versionadded:: master
+
 .. attribute:: LP_ENABLE_TMUX_TITLE_PANES
    :type: bool
    :value: 1

--- a/liquidprompt
+++ b/liquidprompt
@@ -663,6 +663,7 @@ __lp_source_config() {
     LP_ENABLE_TITLE=${LP_ENABLE_TITLE:-0}
     LP_ENABLE_SCREEN_TITLE=${LP_ENABLE_SCREEN_TITLE:-0}
     LP_ENABLE_TITLE_COMMAND=${LP_ENABLE_TITLE_COMMAND:-1}
+    LP_ENABLE_TITLE_COMMAND_ONLY=${LP_ENABLE_TITLE_COMMAND:-0}
     LP_ENABLE_TMUX_TITLE_PANES=${LP_ENABLE_TMUX_TITLE_PANES:-1}
     LP_ENABLE_SSH_COLORS=${LP_ENABLE_SSH_COLORS:-0}
     LP_DISABLED_VCS_PATHS=( ${LP_DISABLED_VCS_PATHS[@]+"${LP_DISABLED_VCS_PATHS[@]}"} )
@@ -1101,6 +1102,7 @@ lp_activate() {
 
     # Can not show title command if the title feature is disabled.
     (( LP_ENABLE_TITLE )) || LP_ENABLE_TITLE_COMMAND=0
+    (( LP_ENABLE_TITLE_COMMAND )) || LP_ENABLE_TITLE_COMMAND_ONLY=0
 
     # update_terminal_cwd is a shell function available on MacOS X Lion that
     # will update an icon of the directory displayed in the title of the terminal
@@ -4701,8 +4703,12 @@ fi
 __lp_print_title_command() {
     local command
     __lp_get_last_command_line
-
-    printf '%s' "${LP_TITLE_OPEN}${_lp_manual_title:-${_lp_generated_title-${SHELL+"$SHELL \$ "}}}${command}${LP_TITLE_CLOSE}"
+    # If $command is not set or is empty fallback to the original behavior
+    if [[ -n "$command" ]] && (( LP_ENABLE_TITLE_COMMAND_ONLY )); then
+        printf '%s' "${LP_TITLE_OPEN}${_lp_manual_title}${command}${LP_TITLE_CLOSE}"
+    else
+        printf '%s' "${LP_TITLE_OPEN}${_lp_manual_title:-${_lp_generated_title-${SHELL+"$SHELL \$ "}}}${command}${LP_TITLE_CLOSE}"
+    fi
 }
 
 ###################

--- a/liquidprompt
+++ b/liquidprompt
@@ -663,7 +663,7 @@ __lp_source_config() {
     LP_ENABLE_TITLE=${LP_ENABLE_TITLE:-0}
     LP_ENABLE_SCREEN_TITLE=${LP_ENABLE_SCREEN_TITLE:-0}
     LP_ENABLE_TITLE_COMMAND=${LP_ENABLE_TITLE_COMMAND:-1}
-    LP_ENABLE_TITLE_COMMAND_ONLY=${LP_ENABLE_TITLE_COMMAND:-0}
+    LP_ENABLE_TITLE_COMMAND_ONLY=${LP_ENABLE_TITLE_COMMAND_ONLY:-0}
     LP_ENABLE_TMUX_TITLE_PANES=${LP_ENABLE_TMUX_TITLE_PANES:-1}
     LP_ENABLE_SSH_COLORS=${LP_ENABLE_SSH_COLORS:-0}
     LP_DISABLED_VCS_PATHS=( ${LP_DISABLED_VCS_PATHS[@]+"${LP_DISABLED_VCS_PATHS[@]}"} )
@@ -4705,7 +4705,7 @@ __lp_print_title_command() {
     __lp_get_last_command_line
     # If $command is not set or is empty fallback to the original behavior
     if [[ -n "$command" ]] && (( LP_ENABLE_TITLE_COMMAND_ONLY )); then
-        printf '%s' "${LP_TITLE_OPEN}${_lp_manual_title}${command}${LP_TITLE_CLOSE}"
+        printf '%s' "${LP_TITLE_OPEN}${_lp_manual_title:-}${command}${LP_TITLE_CLOSE}"
     else
         printf '%s' "${LP_TITLE_OPEN}${_lp_manual_title:-${_lp_generated_title-${SHELL+"$SHELL \$ "}}}${command}${LP_TITLE_CLOSE}"
     fi


### PR DESCRIPTION
This PR adds an option to use only the current command in the terminal title.
* Added `LP_ENABLE_TITLE_COMMAND_ONLY` option with a default of `0`
* Added a few lines to `__lp_print_title_command` to change the text used for the terminal title based on the config

 Related issue: #861

# Technical checklist:

- code follows our [shell standards](https://github.com/liquidprompt/liquidprompt/wiki/Shell-standards):
    - [x] correct use of `IFS`
    - [x] careful quoting
    - [x] cautious array access
    - [x] portable array indexing with `_LP_FIRST_INDEX`
    - [x] printing a "%" character is done with `_LP_PERCENT`
    - [x] functions/variable naming conventions
    - [x] functions have local variables
    - [x] data functions have optimization guards (early exits)
    - [x] subshells are avoided as much as possible
    - [x] string substitutions may be done differently in Bash and Zsh (use `_LP_SHELL_*`)
- tests and checks have been added, run, and their warnings fixed:
    - [n] unit tests have been updated (see `tests/test_*.sh` files)
        - I didn't see any tests related to the `LP_ENABLE_TITLE_*` options so I didn't add any
    - [x] ran `tests.sh`
    - [x] ran `shellcheck.sh` (requires [shellcheck](https://github.com/koalaman/shellcheck#user-content-installing))
- documentation has been updated accordingly:
    - [x] functions and attributes are documented in alphabetical order
    - [x] new sections are documented in the default theme
    - [x] tag `.. versionadded:: X.Y` or `.. versionchanged:: Y.Z`
        - Set to `.. versionadded:: master` since I don't know what version it will be in.
    - [x] function signatures have arguments, returned code, and set value(s)
    - [x] attributes have types and defaults
    - [x] ran `docs/docs-lint.sh` (requires Python 3 and `requirements.txt`
          installed (`cd docs/; python3 -m venv venv; . venv/bin/activate; pip install -r requirements.txt`))