### PR TITLE
Feat: option to truncate from FQDN

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1289,6 +1289,19 @@ Features
 
    See also: :attr:`LP_COLOR_HOST` and :attr:`LP_ENABLE_SSH_COLORS`.
 
+.. attribute:: LP_HOSTNAME_FQDN_TRIM
+   :type: int or string
+   :value: 0
+
+   The number of domain sections to remove from the end of the fully qualified
+   domain name when :attr:`LP_HOSTNAME_METHOD` is set to `fqdn`. If set to a
+   string instead of a number, remove that domain suffix from the end (e.g.
+   ``example.net`` turns ``foo.bar.example.net`` into ``foo.bar``).
+
+   See also: :attr:`LP_HOSTNAME_METHOD`.
+
+   .. versionadded:: 2.4
+
 .. attribute:: LP_HOSTNAME_METHOD
    :type: string
    :value: "short"
@@ -1300,7 +1313,8 @@ Features
    * **full**: show the full hostname, without any domain name. Equal to ``\H``
      in Bash or ``%M`` in Zsh.
    * **fqdn**: show the fully qualified domain name, if it exists. Defaults to
-     **full** if not.
+     **full** if not. See :attr:`LP_HOSTNAME_FQDN_TRIM` to remove domain
+     sections from the end.
    * **pretty**: show the pretty hostname, also called "machine display name".
      Defaults to **full** if one does not exist.
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1300,12 +1300,11 @@ Features
    * **full**: show the full hostname, without any domain name. Equal to ``\H``
      in Bash or ``%M`` in Zsh.
    * **fqdn**: show the fully qualified domain name, if it exists. Defaults to
-     **full** if not. See :attr:`LP_HOSTNAME_TRIM` to remove domain sections
-     from the end.
+     **full** if not.
    * **pretty**: show the pretty hostname, also called "machine display name".
      Defaults to **full** if one does not exist.
 
-   See also: :attr:`LP_HOSTNAME_ALWAYS`.
+   See also: :attr:`LP_HOSTNAME_ALWAYS` and :attr:`LP_HOSTNAME_TRIM`.
 
    .. versionadded:: 2.1
 
@@ -1313,10 +1312,10 @@ Features
    :type: int or string
    :value: 0
 
-   The number of domain sections to remove from the end of the fully qualified
-   domain name when :attr:`LP_HOSTNAME_METHOD` is set to `fqdn`. If set to a
-   string instead of a number, remove that domain suffix from the end (e.g.
-   ``example.net`` turns ``foo.bar.example.net`` into ``foo.bar``).
+   The number of domain sections to remove from the end of the hostname, after
+   :attr:`LP_HOSTNAME_METHOD` is applied. If set to a string instead of a
+   number, remove that domain suffix from the end (e.g. ``example.net`` turns
+   ``foo.bar.example.net`` into ``foo.bar``).
 
    See also: :attr:`LP_HOSTNAME_METHOD`.
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1296,7 +1296,8 @@ Features
    Determine the method for displaying the hostname.
 
    * **short**: show the first section of the hostname, what is before the first
-     dot. Equal to ``\h`` in Bash or ``%m`` in Zsh.
+     dot. Equal to ``\h`` in Bash or ``%m`` in Zsh. An alias for **full** with
+     :attr:`LP_HOSTNAME_TRIM` set to ``-1``, overriding any configured value.
    * **full**: show the full hostname, without any domain name. Equal to ``\H``
      in Bash or ``%M`` in Zsh.
    * **fqdn**: show the fully qualified domain name, if it exists. Defaults to
@@ -1308,6 +1309,10 @@ Features
 
    .. versionadded:: 2.1
 
+   .. versionchanged:: 2.4
+      The **short** method is now an alias for **full** with
+      :attr:`LP_HOSTNAME_TRIM` set to ``-1``.
+
 .. attribute:: LP_HOSTNAME_TRIM
    :type: int or string
    :value: 0
@@ -1318,6 +1323,9 @@ Features
    ``foo``). If set to a string instead of a number, remove that domain suffix
    from the end (e.g. ``example.net`` turns ``foo.bar.example.net`` into
    ``foo.bar``).
+
+   Ignored when :attr:`LP_HOSTNAME_METHOD` is set to **short**, which forces
+   this option to ``-1``.
 
    See also: :attr:`LP_HOSTNAME_METHOD`.
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1313,9 +1313,11 @@ Features
    :value: 0
 
    The number of domain sections to remove from the end of the hostname, after
-   :attr:`LP_HOSTNAME_METHOD` is applied. If set to a string instead of a
-   number, remove that domain suffix from the end (e.g. ``example.net`` turns
-   ``foo.bar.example.net`` into ``foo.bar``).
+   :attr:`LP_HOSTNAME_METHOD` is applied. If negative, keep that many sections
+   from the start instead (e.g. ``-1`` turns ``foo.bar.example.net`` into
+   ``foo``). If set to a string instead of a number, remove that domain suffix
+   from the end (e.g. ``example.net`` turns ``foo.bar.example.net`` into
+   ``foo.bar``).
 
    See also: :attr:`LP_HOSTNAME_METHOD`.
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1289,19 +1289,6 @@ Features
 
    See also: :attr:`LP_COLOR_HOST` and :attr:`LP_ENABLE_SSH_COLORS`.
 
-.. attribute:: LP_HOSTNAME_FQDN_TRIM
-   :type: int or string
-   :value: 0
-
-   The number of domain sections to remove from the end of the fully qualified
-   domain name when :attr:`LP_HOSTNAME_METHOD` is set to `fqdn`. If set to a
-   string instead of a number, remove that domain suffix from the end (e.g.
-   ``example.net`` turns ``foo.bar.example.net`` into ``foo.bar``).
-
-   See also: :attr:`LP_HOSTNAME_METHOD`.
-
-   .. versionadded:: 2.4
-
 .. attribute:: LP_HOSTNAME_METHOD
    :type: string
    :value: "short"
@@ -1313,14 +1300,27 @@ Features
    * **full**: show the full hostname, without any domain name. Equal to ``\H``
      in Bash or ``%M`` in Zsh.
    * **fqdn**: show the fully qualified domain name, if it exists. Defaults to
-     **full** if not. See :attr:`LP_HOSTNAME_FQDN_TRIM` to remove domain
-     sections from the end.
+     **full** if not. See :attr:`LP_HOSTNAME_TRIM` to remove domain sections
+     from the end.
    * **pretty**: show the pretty hostname, also called "machine display name".
      Defaults to **full** if one does not exist.
 
    See also: :attr:`LP_HOSTNAME_ALWAYS`.
 
    .. versionadded:: 2.1
+
+.. attribute:: LP_HOSTNAME_TRIM
+   :type: int or string
+   :value: 0
+
+   The number of domain sections to remove from the end of the fully qualified
+   domain name when :attr:`LP_HOSTNAME_METHOD` is set to `fqdn`. If set to a
+   string instead of a number, remove that domain suffix from the end (e.g.
+   ``example.net`` turns ``foo.bar.example.net`` into ``foo.bar``).
+
+   See also: :attr:`LP_HOSTNAME_METHOD`.
+
+   .. versionadded:: 2.4
 
 .. attribute:: LP_PERCENTS_ALWAYS
    :type: bool

--- a/docs/functions/data.rst
+++ b/docs/functions/data.rst
@@ -457,6 +457,10 @@ OS
       No longer sets ``LP_HOST_SYMBOL`` to the same return string.
       Added :attr:`LP_HOSTNAME_METHOD` to configure display method.
 
+   .. versionchanged:: 2.4
+      Added :attr:`LP_HOSTNAME_FQDN_TRIM` to remove domain sections from the
+      `fqdn` method.
+
 .. function:: _lp_os() -> var:lp_os_arch, var:lp_os_family, var:lp_os_kernel, var:lp_os_distrib, var:lp_os_version
 
    Gather data about the current Operating System.

--- a/docs/functions/data.rst
+++ b/docs/functions/data.rst
@@ -459,7 +459,7 @@ OS
 
    .. versionchanged:: 2.4
       Added :attr:`LP_HOSTNAME_TRIM` to remove domain sections from the
-      `fqdn` method.
+      hostname.
 
 .. function:: _lp_os() -> var:lp_os_arch, var:lp_os_family, var:lp_os_kernel, var:lp_os_distrib, var:lp_os_version
 

--- a/docs/functions/data.rst
+++ b/docs/functions/data.rst
@@ -458,7 +458,7 @@ OS
       Added :attr:`LP_HOSTNAME_METHOD` to configure display method.
 
    .. versionchanged:: 2.4
-      Added :attr:`LP_HOSTNAME_FQDN_TRIM` to remove domain sections from the
+      Added :attr:`LP_HOSTNAME_TRIM` to remove domain sections from the
       `fqdn` method.
 
 .. function:: _lp_os() -> var:lp_os_arch, var:lp_os_family, var:lp_os_kernel, var:lp_os_distrib, var:lp_os_version

--- a/docs/functions/internal.rst
+++ b/docs/functions/internal.rst
@@ -27,6 +27,10 @@ Config
       Renamed from ``_lp_source_config``.
       Added ``--no-config`` flag.
 
+   .. versionchanged:: 2.4
+      The **short** :attr:`LP_HOSTNAME_METHOD` is aliased to **full** with
+      :attr:`LP_HOSTNAME_TRIM` set to ``-1``.
+
 Formatting
 ----------
 

--- a/liquidprompt
+++ b/liquidprompt
@@ -608,6 +608,7 @@ __lp_source_config() {
     LP_PATH_VCS_ROOT=${LP_PATH_VCS_ROOT:-1}
     LP_HOSTNAME_ALWAYS=${LP_HOSTNAME_ALWAYS:-0}
     LP_HOSTNAME_METHOD=${LP_HOSTNAME_METHOD:-short}
+    LP_HOSTNAME_TRIM=${LP_HOSTNAME_TRIM:-2}
     LP_USER_ALWAYS=${LP_USER_ALWAYS:-1}
     LP_ALWAYS_DISPLAY_VALUES=${LP_ALWAYS_DISPLAY_VALUES:-1}
     LP_DISPLAY_VALUES_AS_PERCENTS=${LP_DISPLAY_VALUES_AS_PERCENTS:-0}
@@ -2731,7 +2732,7 @@ _lp_hostname() {
             return 1
         fi
 
-        if [[ $LP_HOSTNAME_METHOD == fqdn ]]; then
+        if [[ $LP_HOSTNAME_METHOD == fqdn || $LP_HOSTNAME_METHOD == fqdn_trimmed ]]; then
             lp_hostname=$(hostname -f 2>/dev/null)
         elif [[ $LP_HOSTNAME_METHOD == pretty ]]; then
             if [[ $LP_OS == Darwin ]]; then
@@ -2748,6 +2749,12 @@ _lp_hostname() {
         # Truncate to the first subdomain
         if [[ $LP_HOSTNAME_METHOD == short ]]; then
             lp_hostname=${lp_hostname%%.*}
+        # Truncate domain sections from the end
+        elif [[ $LP_HOSTNAME_METHOD == fqdn_trimmed ]]; then
+            local i
+            for (( i=0; i < LP_HOSTNAME_TRIM; i++ )); do
+                lp_hostname=${lp_hostname%.*}
+            done
         fi
 
         local ret

--- a/liquidprompt
+++ b/liquidprompt
@@ -2752,7 +2752,17 @@ _lp_hostname() {
         fi
 
         # Truncate domain sections from the end
-        if [[ $LP_HOSTNAME_TRIM == *[!0-9]* ]]; then
+        if [[ $LP_HOSTNAME_TRIM == -* ]]; then
+            # Negative: keep that many sections from the start instead
+            local i=$LP_HOSTNAME_TRIM domain=$lp_hostname
+            while (( i < 0 )) && [[ $domain == *.* ]]; do
+                domain=${domain#*.}
+                (( i++ ))
+            done
+            if (( i == 0 )); then
+                lp_hostname=${lp_hostname%".$domain"}
+            fi
+        elif [[ $LP_HOSTNAME_TRIM == *[!0-9]* ]]; then
             # Remove a literal domain suffix and the dot before it
             lp_hostname=${lp_hostname%".${LP_HOSTNAME_TRIM#.}"}
         else

--- a/liquidprompt
+++ b/liquidprompt
@@ -2749,17 +2749,17 @@ _lp_hostname() {
         # Truncate to the first subdomain
         if [[ $LP_HOSTNAME_METHOD == short ]]; then
             lp_hostname=${lp_hostname%%.*}
+        fi
+
         # Truncate domain sections from the end
-        elif [[ $LP_HOSTNAME_METHOD == fqdn ]]; then
-            if [[ $LP_HOSTNAME_TRIM == *[!0-9]* ]]; then
-                # Remove a literal domain suffix and the dot before it
-                lp_hostname=${lp_hostname%".${LP_HOSTNAME_TRIM#.}"}
-            else
-                local i
-                for (( i=0; i < LP_HOSTNAME_TRIM; i++ )); do
-                    lp_hostname=${lp_hostname%.*}
-                done
-            fi
+        if [[ $LP_HOSTNAME_TRIM == *[!0-9]* ]]; then
+            # Remove a literal domain suffix and the dot before it
+            lp_hostname=${lp_hostname%".${LP_HOSTNAME_TRIM#.}"}
+        else
+            local i
+            for (( i=0; i < LP_HOSTNAME_TRIM; i++ )); do
+                lp_hostname=${lp_hostname%.*}
+            done
         fi
 
         local ret

--- a/liquidprompt
+++ b/liquidprompt
@@ -925,6 +925,12 @@ __lp_source_config() {
         LP_HOSTNAME_METHOD="full"
     fi
 
+    # short is an alias for the full method keeping only the first section
+    if [[ $LP_HOSTNAME_METHOD == short ]]; then
+        LP_HOSTNAME_METHOD="full"
+        LP_HOSTNAME_TRIM=-1
+    fi
+
     if [[ -n ${LP_PERCENTS_ALWAYS-} ]]; then
         echo "liquidprompt: LP_PERCENTS_ALWAYS is deprecated. Update your config to set LP_ALWAYS_DISPLAY_VALUES and LP_DISPLAY_VALUES_AS_PERCENTS instead." >&2
         LP_ALWAYS_DISPLAY_VALUES=${LP_PERCENTS_ALWAYS}
@@ -2744,11 +2750,6 @@ _lp_hostname() {
 
         if [[ -z ${lp_hostname-} ]]; then
             lp_hostname=${HOSTNAME:-${HOST-}}
-        fi
-
-        # Truncate to the first subdomain
-        if [[ $LP_HOSTNAME_METHOD == short ]]; then
-            lp_hostname=${lp_hostname%%.*}
         fi
 
         # Truncate domain sections from the end

--- a/liquidprompt
+++ b/liquidprompt
@@ -607,8 +607,8 @@ __lp_source_config() {
     LP_PATH_METHOD=${LP_PATH_METHOD:-truncate_chars_from_path_left}
     LP_PATH_VCS_ROOT=${LP_PATH_VCS_ROOT:-1}
     LP_HOSTNAME_ALWAYS=${LP_HOSTNAME_ALWAYS:-0}
-    LP_HOSTNAME_FQDN_TRIM=${LP_HOSTNAME_FQDN_TRIM:-0}
     LP_HOSTNAME_METHOD=${LP_HOSTNAME_METHOD:-short}
+    LP_HOSTNAME_TRIM=${LP_HOSTNAME_TRIM:-0}
     LP_USER_ALWAYS=${LP_USER_ALWAYS:-1}
     LP_ALWAYS_DISPLAY_VALUES=${LP_ALWAYS_DISPLAY_VALUES:-1}
     LP_DISPLAY_VALUES_AS_PERCENTS=${LP_DISPLAY_VALUES_AS_PERCENTS:-0}
@@ -2751,12 +2751,12 @@ _lp_hostname() {
             lp_hostname=${lp_hostname%%.*}
         # Truncate domain sections from the end
         elif [[ $LP_HOSTNAME_METHOD == fqdn ]]; then
-            if [[ $LP_HOSTNAME_FQDN_TRIM == *[!0-9]* ]]; then
+            if [[ $LP_HOSTNAME_TRIM == *[!0-9]* ]]; then
                 # Remove a literal domain suffix and the dot before it
-                lp_hostname=${lp_hostname%".${LP_HOSTNAME_FQDN_TRIM#.}"}
+                lp_hostname=${lp_hostname%".${LP_HOSTNAME_TRIM#.}"}
             else
                 local i
-                for (( i=0; i < LP_HOSTNAME_FQDN_TRIM; i++ )); do
+                for (( i=0; i < LP_HOSTNAME_TRIM; i++ )); do
                     lp_hostname=${lp_hostname%.*}
                 done
             fi

--- a/liquidprompt
+++ b/liquidprompt
@@ -607,8 +607,8 @@ __lp_source_config() {
     LP_PATH_METHOD=${LP_PATH_METHOD:-truncate_chars_from_path_left}
     LP_PATH_VCS_ROOT=${LP_PATH_VCS_ROOT:-1}
     LP_HOSTNAME_ALWAYS=${LP_HOSTNAME_ALWAYS:-0}
+    LP_HOSTNAME_FQDN_TRIM=${LP_HOSTNAME_FQDN_TRIM:-0}
     LP_HOSTNAME_METHOD=${LP_HOSTNAME_METHOD:-short}
-    LP_HOSTNAME_TRIM=${LP_HOSTNAME_TRIM:-2}
     LP_USER_ALWAYS=${LP_USER_ALWAYS:-1}
     LP_ALWAYS_DISPLAY_VALUES=${LP_ALWAYS_DISPLAY_VALUES:-1}
     LP_DISPLAY_VALUES_AS_PERCENTS=${LP_DISPLAY_VALUES_AS_PERCENTS:-0}
@@ -2732,7 +2732,7 @@ _lp_hostname() {
             return 1
         fi
 
-        if [[ $LP_HOSTNAME_METHOD == fqdn || $LP_HOSTNAME_METHOD == fqdn_trimmed ]]; then
+        if [[ $LP_HOSTNAME_METHOD == fqdn ]]; then
             lp_hostname=$(hostname -f 2>/dev/null)
         elif [[ $LP_HOSTNAME_METHOD == pretty ]]; then
             if [[ $LP_OS == Darwin ]]; then
@@ -2750,11 +2750,16 @@ _lp_hostname() {
         if [[ $LP_HOSTNAME_METHOD == short ]]; then
             lp_hostname=${lp_hostname%%.*}
         # Truncate domain sections from the end
-        elif [[ $LP_HOSTNAME_METHOD == fqdn_trimmed ]]; then
-            local i
-            for (( i=0; i < LP_HOSTNAME_TRIM; i++ )); do
-                lp_hostname=${lp_hostname%.*}
-            done
+        elif [[ $LP_HOSTNAME_METHOD == fqdn ]]; then
+            if [[ $LP_HOSTNAME_FQDN_TRIM == *[!0-9]* ]]; then
+                # Remove a literal domain suffix and the dot before it
+                lp_hostname=${lp_hostname%".${LP_HOSTNAME_FQDN_TRIM#.}"}
+            else
+                local i
+                for (( i=0; i < LP_HOSTNAME_FQDN_TRIM; i++ )); do
+                    lp_hostname=${lp_hostname%.*}
+                done
+            fi
         fi
 
         local ret

--- a/liquidprompt
+++ b/liquidprompt
@@ -2755,7 +2755,7 @@ _lp_hostname() {
         # Truncate domain sections from the end
         if [[ $LP_HOSTNAME_TRIM == -* ]]; then
             # Negative: keep that many sections from the start instead
-            local i=$LP_HOSTNAME_TRIM domain=$lp_hostname
+            local i="$LP_HOSTNAME_TRIM" domain="$lp_hostname"
             while (( i < 0 )) && [[ $domain == *.* ]]; do
                 domain=${domain#*.}
                 (( i++ ))

--- a/tests/test_hostname.sh
+++ b/tests/test_hostname.sh
@@ -40,6 +40,26 @@ function test_hostname_method_fqdn_trim {
   _lp_hostname
   assertEquals "fqdn trim longer than domain" "foo" "$lp_hostname"
 
+  LP_HOSTNAME_TRIM=-1
+  lp_hostname=
+  _lp_hostname
+  assertEquals "fqdn trim of -1 keeps first section" "foo" "$lp_hostname"
+
+  LP_HOSTNAME_TRIM=-2
+  lp_hostname=
+  _lp_hostname
+  assertEquals "fqdn trim of -2 keeps two sections" "foo.bar" "$lp_hostname"
+
+  LP_HOSTNAME_TRIM=-4
+  lp_hostname=
+  _lp_hostname
+  assertEquals "fqdn trim of -4 keeps all sections" "foo.bar.example.com" "$lp_hostname"
+
+  LP_HOSTNAME_TRIM=-5
+  lp_hostname=
+  _lp_hostname
+  assertEquals "fqdn negative trim longer than domain" "foo.bar.example.com" "$lp_hostname"
+
   LP_HOSTNAME_TRIM=example.com
   lp_hostname=
   _lp_hostname
@@ -93,6 +113,11 @@ function test_hostname_method_full_trim {
   lp_hostname=
   _lp_hostname
   assertEquals "full trim of matching domain string" "foo.bar" "$lp_hostname"
+
+  LP_HOSTNAME_TRIM=-1
+  lp_hostname=
+  _lp_hostname
+  assertEquals "full trim of -1 keeps first section" "foo" "$lp_hostname"
 }
 
 function test_hostname_method_short_trim {

--- a/tests/test_hostname.sh
+++ b/tests/test_hostname.sh
@@ -1,0 +1,54 @@
+
+# Error on unset variables
+set -u
+
+if [ -n "${ZSH_VERSION-}" ]; then
+  SHUNIT_PARENT="$0"
+  setopt shwordsplit ksh_arrays
+fi
+
+. ../liquidprompt --no-activate
+
+function test_hostname_method_fqdn_trimmed {
+
+  hostname() {
+    printf 'foo.bar.example.com\n'
+  }
+
+  LP_HOSTNAME_ALWAYS=1
+  LP_HOSTNAME_METHOD=fqdn_trimmed
+
+  typeset lp_hostname
+
+  LP_HOSTNAME_TRIM=2
+  lp_hostname=
+  _lp_hostname
+  assertEquals "fqdn_trimmed trim of 2 (default)" "foo.bar" "$lp_hostname"
+
+  LP_HOSTNAME_TRIM=1
+  lp_hostname=
+  _lp_hostname
+  assertEquals "fqdn_trimmed trim of 1" "foo.bar.example" "$lp_hostname"
+
+  LP_HOSTNAME_TRIM=0
+  lp_hostname=
+  _lp_hostname
+  assertEquals "fqdn_trimmed trim of 0" "foo.bar.example.com" "$lp_hostname"
+
+  LP_HOSTNAME_TRIM=5
+  lp_hostname=
+  _lp_hostname
+  assertEquals "fqdn_trimmed trim longer than domain" "foo" "$lp_hostname"
+
+  hostname() {
+    return 1
+  }
+
+  HOSTNAME=srv.example.com
+  LP_HOSTNAME_TRIM=2
+  lp_hostname=
+  _lp_hostname
+  assertEquals "fqdn_trimmed fallback to full hostname" "srv" "$lp_hostname"
+}
+
+. ./shunit2

--- a/tests/test_hostname.sh
+++ b/tests/test_hostname.sh
@@ -9,46 +9,66 @@ fi
 
 . ../liquidprompt --no-activate
 
-function test_hostname_method_fqdn_trimmed {
+function test_hostname_method_fqdn_trim {
 
   hostname() {
     printf 'foo.bar.example.com\n'
   }
 
   LP_HOSTNAME_ALWAYS=1
-  LP_HOSTNAME_METHOD=fqdn_trimmed
+  LP_HOSTNAME_METHOD=fqdn
 
   typeset lp_hostname
 
-  LP_HOSTNAME_TRIM=2
+  LP_HOSTNAME_FQDN_TRIM=0
   lp_hostname=
   _lp_hostname
-  assertEquals "fqdn_trimmed trim of 2 (default)" "foo.bar" "$lp_hostname"
+  assertEquals "fqdn trim of 0 (default)" "foo.bar.example.com" "$lp_hostname"
 
-  LP_HOSTNAME_TRIM=1
+  LP_HOSTNAME_FQDN_TRIM=1
   lp_hostname=
   _lp_hostname
-  assertEquals "fqdn_trimmed trim of 1" "foo.bar.example" "$lp_hostname"
+  assertEquals "fqdn trim of 1" "foo.bar.example" "$lp_hostname"
 
-  LP_HOSTNAME_TRIM=0
+  LP_HOSTNAME_FQDN_TRIM=2
   lp_hostname=
   _lp_hostname
-  assertEquals "fqdn_trimmed trim of 0" "foo.bar.example.com" "$lp_hostname"
+  assertEquals "fqdn trim of 2" "foo.bar" "$lp_hostname"
 
-  LP_HOSTNAME_TRIM=5
+  LP_HOSTNAME_FQDN_TRIM=5
   lp_hostname=
   _lp_hostname
-  assertEquals "fqdn_trimmed trim longer than domain" "foo" "$lp_hostname"
+  assertEquals "fqdn trim longer than domain" "foo" "$lp_hostname"
+
+  LP_HOSTNAME_FQDN_TRIM=example.com
+  lp_hostname=
+  _lp_hostname
+  assertEquals "fqdn trim of matching domain string" "foo.bar" "$lp_hostname"
+
+  LP_HOSTNAME_FQDN_TRIM=.example.com
+  lp_hostname=
+  _lp_hostname
+  assertEquals "fqdn trim of domain string with leading dot" "foo.bar" "$lp_hostname"
+
+  LP_HOSTNAME_FQDN_TRIM=example.org
+  lp_hostname=
+  _lp_hostname
+  assertEquals "fqdn trim of non-matching domain string" "foo.bar.example.com" "$lp_hostname"
+
+  LP_HOSTNAME_FQDN_TRIM=foo.bar.example.com
+  lp_hostname=
+  _lp_hostname
+  assertEquals "fqdn trim of entire hostname string" "foo.bar.example.com" "$lp_hostname"
 
   hostname() {
     return 1
   }
 
   HOSTNAME=srv.example.com
-  LP_HOSTNAME_TRIM=2
+  LP_HOSTNAME_FQDN_TRIM=2
   lp_hostname=
   _lp_hostname
-  assertEquals "fqdn_trimmed fallback to full hostname" "srv" "$lp_hostname"
+  assertEquals "fqdn trim fallback to full hostname" "srv" "$lp_hostname"
 }
 
 . ./shunit2

--- a/tests/test_hostname.sh
+++ b/tests/test_hostname.sh
@@ -20,42 +20,42 @@ function test_hostname_method_fqdn_trim {
 
   typeset lp_hostname
 
-  LP_HOSTNAME_FQDN_TRIM=0
+  LP_HOSTNAME_TRIM=0
   lp_hostname=
   _lp_hostname
   assertEquals "fqdn trim of 0 (default)" "foo.bar.example.com" "$lp_hostname"
 
-  LP_HOSTNAME_FQDN_TRIM=1
+  LP_HOSTNAME_TRIM=1
   lp_hostname=
   _lp_hostname
   assertEquals "fqdn trim of 1" "foo.bar.example" "$lp_hostname"
 
-  LP_HOSTNAME_FQDN_TRIM=2
+  LP_HOSTNAME_TRIM=2
   lp_hostname=
   _lp_hostname
   assertEquals "fqdn trim of 2" "foo.bar" "$lp_hostname"
 
-  LP_HOSTNAME_FQDN_TRIM=5
+  LP_HOSTNAME_TRIM=5
   lp_hostname=
   _lp_hostname
   assertEquals "fqdn trim longer than domain" "foo" "$lp_hostname"
 
-  LP_HOSTNAME_FQDN_TRIM=example.com
+  LP_HOSTNAME_TRIM=example.com
   lp_hostname=
   _lp_hostname
   assertEquals "fqdn trim of matching domain string" "foo.bar" "$lp_hostname"
 
-  LP_HOSTNAME_FQDN_TRIM=.example.com
+  LP_HOSTNAME_TRIM=.example.com
   lp_hostname=
   _lp_hostname
   assertEquals "fqdn trim of domain string with leading dot" "foo.bar" "$lp_hostname"
 
-  LP_HOSTNAME_FQDN_TRIM=example.org
+  LP_HOSTNAME_TRIM=example.org
   lp_hostname=
   _lp_hostname
   assertEquals "fqdn trim of non-matching domain string" "foo.bar.example.com" "$lp_hostname"
 
-  LP_HOSTNAME_FQDN_TRIM=foo.bar.example.com
+  LP_HOSTNAME_TRIM=foo.bar.example.com
   lp_hostname=
   _lp_hostname
   assertEquals "fqdn trim of entire hostname string" "foo.bar.example.com" "$lp_hostname"
@@ -65,7 +65,7 @@ function test_hostname_method_fqdn_trim {
   }
 
   HOSTNAME=srv.example.com
-  LP_HOSTNAME_FQDN_TRIM=2
+  LP_HOSTNAME_TRIM=2
   lp_hostname=
   _lp_hostname
   assertEquals "fqdn trim fallback to full hostname" "srv" "$lp_hostname"

--- a/tests/test_hostname.sh
+++ b/tests/test_hostname.sh
@@ -9,6 +9,9 @@ fi
 
 . ../liquidprompt --no-activate
 
+# Liquidprompt depends on PS1 being set to detect if it has installed itself.
+PS1="$ "
+
 function test_hostname_method_fqdn_trim {
 
   hostname() {
@@ -124,19 +127,19 @@ function test_hostname_method_short_trim {
 
   LP_HOSTNAME_ALWAYS=1
   LP_HOSTNAME_METHOD=short
+  LP_HOSTNAME_TRIM=2
   HOSTNAME=foo.bar.example.com
 
+  # short is aliased to full with LP_HOSTNAME_TRIM=-1 at config load
+  lp_activate --no-config
+
+  assertEquals "short is aliased to full" "full" "$LP_HOSTNAME_METHOD"
+  assertEquals "short overrides LP_HOSTNAME_TRIM" "-1" "$LP_HOSTNAME_TRIM"
+
   typeset lp_hostname
-
-  LP_HOSTNAME_TRIM=0
   lp_hostname=
   _lp_hostname
-  assertEquals "short trim of 0 (default)" "foo" "$lp_hostname"
-
-  LP_HOSTNAME_TRIM=2
-  lp_hostname=
-  _lp_hostname
-  assertEquals "short trim of 2 is a no-op" "foo" "$lp_hostname"
+  assertEquals "short shows the first section" "foo" "$lp_hostname"
 }
 
 . ./shunit2

--- a/tests/test_hostname.sh
+++ b/tests/test_hostname.sh
@@ -71,4 +71,47 @@ function test_hostname_method_fqdn_trim {
   assertEquals "fqdn trim fallback to full hostname" "srv" "$lp_hostname"
 }
 
+function test_hostname_method_full_trim {
+
+  LP_HOSTNAME_ALWAYS=1
+  LP_HOSTNAME_METHOD=full
+  HOSTNAME=foo.bar.example.com
+
+  typeset lp_hostname
+
+  LP_HOSTNAME_TRIM=0
+  lp_hostname=
+  _lp_hostname
+  assertEquals "full trim of 0 (default)" "foo.bar.example.com" "$lp_hostname"
+
+  LP_HOSTNAME_TRIM=2
+  lp_hostname=
+  _lp_hostname
+  assertEquals "full trim of 2" "foo.bar" "$lp_hostname"
+
+  LP_HOSTNAME_TRIM=example.com
+  lp_hostname=
+  _lp_hostname
+  assertEquals "full trim of matching domain string" "foo.bar" "$lp_hostname"
+}
+
+function test_hostname_method_short_trim {
+
+  LP_HOSTNAME_ALWAYS=1
+  LP_HOSTNAME_METHOD=short
+  HOSTNAME=foo.bar.example.com
+
+  typeset lp_hostname
+
+  LP_HOSTNAME_TRIM=0
+  lp_hostname=
+  _lp_hostname
+  assertEquals "short trim of 0 (default)" "foo" "$lp_hostname"
+
+  LP_HOSTNAME_TRIM=2
+  lp_hostname=
+  _lp_hostname
+  assertEquals "short trim of 2 is a no-op" "foo" "$lp_hostname"
+}
+
 . ./shunit2


### PR DESCRIPTION
<!-- Provide a description here -->
Adds `LP_HOSTNAME_FQDN_TRIM` setting that can remove end of FQDN based on domain segments or a static string.

IOW, turn `foo.bar.example.net` into `foo.bar` with `LP_HOSTNAME_FQDN_TRIM=2` or `LP_HOSTNAME_FQDN_TRIM=example.net`.

At my work we set hostnames to things like `svc.site.example.net` or `b.svc.site.example.net`. The FQDN is unnecessarily long in a prompt, but just `svc` or `b` is not enough information. This is a way to make that usable for me, and I figured it's reasonably likely to be useful for others.

<!-- Related issue: #XXX -->

# Technical checklist:

- code follows our [shell standards](https://github.com/liquidprompt/liquidprompt/wiki/Shell-standards):
    - [x] correct use of `IFS`
    - [x] careful quoting
    - [x] cautious array access
    - [x] portable array indexing with `_LP_FIRST_INDEX`
    - [x] printing a "%" character is done with `_LP_PERCENT`
    - [x] functions/variable naming conventions
    - [x] functions have local variables
    - [x] data functions have optimization guards (early exits)
    - [x] subshells are avoided as much as possible
    - [x] string substitutions may be done differently in Bash and Zsh (use `_LP_SHELL_*`)
- tests and checks have been added, run, and their warnings fixed:
    - [x] unit tests have been updated (see `tests/test_*.sh` files)
    - [x] ran `tests.sh`
    - [x] ran `shellcheck.sh` (requires [shellcheck](https://github.com/koalaman/shellcheck#user-content-installing))
- documentation has been updated accordingly:
    - [x] functions and attributes are documented in alphabetical order
    - [x] new sections are documented in the default theme
    - [x] tag `.. versionadded:: X.Y` or `.. versionchanged:: Y.Z`
    - [x] function signatures have arguments, returned code, and set value(s)
    - [x] attributes have types and defaults
    - [x] ran `docs/docs-lint.sh` (requires Python 3 and `requirements.txt`
          installed (`cd docs/; python3 -m venv venv; . venv/bin/activate; pip install -r requirements.txt`))

