### PR TITLE
Add herdr as detected session multiplexer

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -457,7 +457,8 @@ Features
 
    Display the number of detached multiplexer sessions.
 
-   Will be disabled if none of ``screen``, ``shpool``, or ``tmux`` are found.
+   Will be disabled if none of ``screen``, ``shpool``, ``tmux``, or
+   ``herdr`` are found.
 
    .. note::
       This can be slow on some machines, and prompt speed can be greatly
@@ -795,7 +796,7 @@ Features
    :value: 1
 
    Allows getting the name of the current multiplexer
-   (*screen*, *shpool*, or *tmux*), if any.
+   (*screen*, *shpool*, *tmux*, or *herdr*), if any.
 
    If set to ``0``, also disables:
 

--- a/docs/functions/data.rst
+++ b/docs/functions/data.rst
@@ -338,6 +338,7 @@ Environment
    * ``tmux``
    * ``screen``
    * ``shpool``
+   * ``herdr``
 
    .. versionadded:: 2.0
 
@@ -345,6 +346,9 @@ Environment
       Can be disabled by :attr:`LP_ENABLE_MULTIPLEXER`,
       except if ``--internal`` is passed (i.e. for internal use only).
       Return variable renamed from ``lp_mulitplexer`` to ``lp_multiplexer``.
+
+   .. versionchanged:: 2.4
+      Added support for ``herdr``.
 
 .. function:: _lp_shell_level() -> var:lp_shell_level
 
@@ -379,6 +383,9 @@ Jobs
    Can be disabled by :attr:`LP_ENABLE_DETACHED_SESSIONS`.
 
    .. versionadded:: 2.0
+
+   .. versionchanged:: 2.4
+      Added support for ``herdr``.
 
 .. function:: _lp_jobcount() -> var:lp_running_jobs, var:lp_stopped_jobs
 

--- a/docs/functions/theme.rst
+++ b/docs/functions/theme.rst
@@ -251,8 +251,8 @@ specific text and formatting may change.
    :attr:`LP_COLOR_JOB_Z`.
 
    Return code is :func:`_lp_detached_sessions` `ORed` with
-   :func:`_lp_jobcount`: both must return no data for :func:`_lp_jobcount_color`
-   to return no data.
+   :func:`_lp_jobcount`: both must return no data for
+   :func:`_lp_jobcount_color` to return no data.
 
    .. versionchanged:: 2.0
       Return code matches data function.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -69,7 +69,8 @@ they require.
 
    * Terminal formatting requires ``tput``.
    * Time display requires ``date``.
-   * Detached session status looks for ``screen``, ``shpool``, and/or ``tmux``.
+   * Detached session status looks for ``screen``, ``shpool``, ``tmux``,
+     and/or ``herdr``.
    * VCS support features require ``git``, ``hg``, ``svn``, ``bzr`` or
      ``fossil`` for their respective repositories.
 

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -85,7 +85,7 @@ These are some of the most popular features:
   much.
 - **Sudo**: show if the user currently has *sudo* rights.
 - **Multiplexers**: indicate if you are in a terminal multiplexer session
-  (i.e. tmux, screen, or shpool).
+  (i.e. tmux, screen, shpool, or herdr).
 - **Proxy**: indicate whether a proxy is configured.
 - **Temperature**: warn if the temperature goes too high.
 - **Hot prompt switch**: commands allowing you to rapidly switch the theme,

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -29,6 +29,7 @@ dBm
 deprecations
 filename
 filepath
+herdr
 hostname
 incrementing
 js
@@ -52,7 +53,6 @@ runtime
 shareable
 shpool
 startup
-stdout
 stdout
 subdirectory
 subshells

--- a/liquidprompt
+++ b/liquidprompt
@@ -1085,13 +1085,14 @@ lp_activate() {
         command -v screen >/dev/null ; _LP_ENABLE_SCREEN=$(( ! $? ))
         command -v tmux >/dev/null   ; _LP_ENABLE_TMUX=$(( ! $? ))
         command -v shpool >/dev/null ; _LP_ENABLE_SHPOOL=$(( ! $? ))
+        command -v herdr >/dev/null  ; _LP_ENABLE_HERDR=$(( ! $? ))
     fi
 
     # Use standard path symbols inside Midnight Commander
     [[ -n "${MC_SID-}" ]] && LP_ENABLE_SHORTEN_PATH=0
 
     # If we are running in a terminal multiplexer, special title escapes
-    if _lp_multiplexer --internal && [[ $lp_multiplexer != "shpool" ]]; then
+    if _lp_multiplexer --internal && [[ $lp_multiplexer == "screen" || $lp_multiplexer == "tmux" ]]; then
         (( LP_ENABLE_TITLE = LP_ENABLE_TITLE && LP_ENABLE_SCREEN_TITLE ))
         if (( LP_ENABLE_TMUX_TITLE_PANES )) && [[ $lp_multiplexer == tmux ]]; then
             LP_TITLE_OPEN=$'\E]2;'
@@ -2199,6 +2200,9 @@ _lp_multiplexer() { # [--internal]
     elif [[ -n ${SHPOOL_SESSION_NAME-} ]]; then
         lp_multiplexer=shpool
         return 0
+    elif [[ -n ${HERDR_SESSION-} || -n ${HERDR_SESSION_NAME-} || -n ${HERDR_ENV-} ]]; then
+        lp_multiplexer=herdr
+        return 0
     fi
     return 1
 }
@@ -2875,7 +2879,7 @@ _lp_shell_level_color() {
 # Related jobs #
 ################
 
-# Return the count of detached screen, tmux, and shpool sessions.
+# Return the count of detached screen, tmux, shpool, and herdr sessions.
 _lp_detached_sessions() {
     (( LP_ENABLE_DETACHED_SESSIONS )) || return 2
 
@@ -2883,6 +2887,7 @@ _lp_detached_sessions() {
     (( _LP_ENABLE_SCREEN )) && count=$(screen -ls 2> /dev/null | GREP_OPTIONS='' \grep -c '[Dd]etach[^)]*)$')
     (( _LP_ENABLE_TMUX )) && count+=$(tmux list-sessions 2> /dev/null | GREP_OPTIONS='' \grep -cv 'attached')
     (( _LP_ENABLE_SHPOOL )) && count+=$(shpool list 2> /dev/null | GREP_OPTIONS='' \grep -c 'disconnected')
+    (( _LP_ENABLE_HERDR )) && count+=$(herdr session list 2> /dev/null | GREP_OPTIONS='' \grep -c '[[:space:]]detached$')
     lp_detached_sessions=$count
 
     (( lp_detached_sessions ))

--- a/tests/test_detached_sessions.sh
+++ b/tests/test_detached_sessions.sh
@@ -13,8 +13,10 @@ LP_ENABLE_DETACHED_SESSIONS=1
 _LP_ENABLE_SCREEN=1
 _LP_ENABLE_TMUX=1
 _LP_ENABLE_SHPOOL=1
+_LP_ENABLE_HERDR=1
+unset HERDR_SESSION HERDR_SESSION_NAME HERDR_ENV
 
-typeset -a screen_outputs screen_values shpool_outputs shpool_values tmux_outputs tmux_values
+typeset -a screen_outputs screen_values shpool_outputs shpool_values tmux_outputs tmux_values herdr_outputs herdr_values
 
 # Add test cases to these arrays like below
 
@@ -90,6 +92,18 @@ test   	2024-09-26T16:06:07.352+00:00  	disconnected
 )
 shpool_values+=(1)
 
+herdr_outputs+=(
+"NAME   STATUS
+"
+)
+herdr_values+=(0)
+herdr_outputs+=(
+"NAME   STATUS
+main   detached
+"
+)
+herdr_values+=(1)
+
 
 function test_screen_sessions {
 
@@ -98,6 +112,7 @@ function test_screen_sessions {
   }
   shpool() { : ; }
   tmux() { : ; }
+  herdr() { : ; }
 
   for (( index=0; index < ${#screen_values[@]}; index++ )); do
     __screen_output=${screen_outputs[$index]}
@@ -113,6 +128,7 @@ function test_shpool_sessions {
   }
   screen() { : ; }
   tmux() { : ; }
+  herdr() { : ; }
 
   for (( index=0; index < ${#shpool_values[@]}; index++ )); do
     __shpool_output=${shpool_outputs[$index]}
@@ -128,12 +144,45 @@ function test_tmux_sessions {
   }
   screen() { : ; }
   shpool() { : ; }
+  herdr() { : ; }
 
   for (( index=0; index < ${#tmux_values[@]}; index++ )); do
     __tmux_output=${tmux_outputs[$index]}
     _lp_detached_sessions
     assertEquals "Tmux sessions output at index ${index}" "${tmux_values[$index]}" "$lp_detached_sessions"
   done
+}
+
+function test_herdr_sessions {
+
+  herdr() {
+    printf '%s' "$__herdr_output"
+  }
+  screen() { : ; }
+  shpool() { : ; }
+  tmux() { : ; }
+
+  for (( index=0; index < ${#herdr_values[@]}; index++ )); do
+    __herdr_output=${herdr_outputs[$index]}
+    _lp_detached_sessions
+    assertEquals "herdr sessions output at index ${index}" "${herdr_values[$index]}" "$lp_detached_sessions"
+  done
+}
+
+function test_herdr_attached_session {
+
+  herdr() {
+    printf '%s' "NAME   STATUS
+main   running
+sub    detached
+"
+  }
+  screen() { : ; }
+  shpool() { : ; }
+  tmux() { : ; }
+
+  _lp_detached_sessions
+  assertEquals "herdr detached sessions count" "1" "$lp_detached_sessions"
 }
 
 . ./shunit2

--- a/tools/external-tool-tester.sh
+++ b/tools/external-tool-tester.sh
@@ -75,6 +75,7 @@ test_tool logname
 test_tool screen -ls
 test_tool shpool list
 test_tool tmux list-sessions
+test_tool herdr session list
 
 for power_supply in "/sys/class/power_supply/"*; do
   for interface in "${power_supply}/"*; do


### PR DESCRIPTION
Detect active and detached herdr sessions alongside screen, tmux, and shpool. Include herdr in the detached sessions count (`d`) and detect when running inside a herdr session context.

### Summary

Adds detection support for the `herdr` terminal session multiplexer.

- Detects when running inside a `herdr` session context (`HERDR_SESSION`, `HERDR_SESSION_NAME`, `HERDR_ENV`).
- Integrates `herdr` into `_lp_detached_sessions()` under the standard `d` detached session indicator.
- Excludes `herdr` from terminal title escape overrides inside `lp_activate()`.
- Updates documentation, color presets, tool tester, and test suite.

# Technical checklist:

- code follows our [shell standards](https://github.com/liquidprompt/liquidprompt/wiki/Shell-standards):
    - [x] correct use of `IFS`
    - [x] careful quoting
    - [x] cautious array access
    - [x] portable array indexing with `_LP_FIRST_INDEX`
    - [x] printing a "%" character is done with `_LP_PERCENT`
    - [x] functions/variable naming conventions
    - [x] functions have local variables
    - [x] data functions have optimization guards (early exits)
    - [x] subshells are avoided as much as possible
    - [x] string substitutions may be done differently in Bash and Zsh (use `_LP_SHELL_*`)
- tests and checks have been added, run, and their warnings fixed:
    - [x] unit tests have been updated (see `tests/test_*.sh` files)
    - [x] ran `tests.sh`
    - [x] ran `shellcheck.sh` (requires [shellcheck](https://github.com/koalaman/shellcheck#user-content-installing))
- documentation has been updated accordingly:
    - [x] functions and attributes are documented in alphabetical order
    - [x] new sections are documented in the default theme
    - [x] tag `.. versionadded:: X.Y` or `.. versionchanged:: Y.Z`
    - [x] function signatures have arguments, returned code, and set value(s)
    - [x] attributes have types and defaults
    - [x] ran `docs/docs-lint.sh` (requires Python 3 and `requirements.txt`
          installed (`cd docs/; python3 -m venv venv; . venv/bin/activate; pip install -r requirements.txt`))