### PR TITLE
Exclude current session from attached multiplexer sessions count

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -451,6 +451,20 @@ Features
 
    .. versionadded:: 2.1
 
+.. attribute:: LP_ATTACHED_SESSIONS_EXCLUDE_CURRENT
+   :type: bool
+   :value: 0
+
+   Exclude the current session from the attached multiplexer session count.
+
+   When enabled (``1``) and running inside an active multiplexer session, the
+   current session is subtracted from the attached session count so that only
+   other attached sessions on the host are counted.
+
+   See also: :attr:`LP_ENABLE_ATTACHED_SESSIONS`.
+
+   .. versionadded:: 2.4
+
 .. attribute:: LP_ENABLE_ATTACHED_SESSIONS
    :type: bool
    :value: 0

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -451,25 +451,14 @@ Features
 
    .. versionadded:: 2.1
 
-.. attribute:: LP_ATTACHED_SESSIONS_EXCLUDE_CURRENT
-   :type: bool
-   :value: 0
-
-   Exclude the current session from the attached multiplexer session count.
-
-   When enabled (``1``) and running inside an active multiplexer session, the
-   current session is subtracted from the attached session count so that only
-   other attached sessions on the host are counted.
-
-   See also: :attr:`LP_ENABLE_ATTACHED_SESSIONS`.
-
-   .. versionadded:: 2.4
-
 .. attribute:: LP_ENABLE_ATTACHED_SESSIONS
    :type: bool
    :value: 0
 
    Display the number of attached running multiplexer sessions.
+
+   If currently running inside an active multiplexer session, the current
+   session is excluded from the count.
 
    Will be disabled if none of ``screen``, ``shpool``, ``tmux``, or
    ``herdr`` are found.

--- a/docs/functions/data.rst
+++ b/docs/functions/data.rst
@@ -380,7 +380,8 @@ Jobs
    Returns ``true`` if any attached running multiplexer sessions are found.
    Returns an integer count of how many sessions were found.
 
-   Can be enabled by :attr:`LP_ENABLE_ATTACHED_SESSIONS`.
+   Can be enabled by :attr:`LP_ENABLE_ATTACHED_SESSIONS`. The current session
+   can be excluded by :attr:`LP_ATTACHED_SESSIONS_EXCLUDE_CURRENT`.
 
    .. versionadded:: 2.4
 

--- a/docs/functions/data.rst
+++ b/docs/functions/data.rst
@@ -380,8 +380,10 @@ Jobs
    Returns ``true`` if any attached running multiplexer sessions are found.
    Returns an integer count of how many sessions were found.
 
-   Can be enabled by :attr:`LP_ENABLE_ATTACHED_SESSIONS`. The current session
-   can be excluded by :attr:`LP_ATTACHED_SESSIONS_EXCLUDE_CURRENT`.
+   If currently running inside an active multiplexer session, the current
+   session is excluded from the count.
+
+   Can be enabled by :attr:`LP_ENABLE_ATTACHED_SESSIONS`.
 
    .. versionadded:: 2.4
 

--- a/liquidprompt
+++ b/liquidprompt
@@ -630,6 +630,7 @@ __lp_source_config() {
     LP_ENABLE_JOBS=${LP_ENABLE_JOBS:-1}
     LP_ENABLE_DETACHED_SESSIONS=${LP_ENABLE_DETACHED_SESSIONS:-1}
     LP_ENABLE_ATTACHED_SESSIONS=${LP_ENABLE_ATTACHED_SESSIONS:-0}
+    LP_ATTACHED_SESSIONS_EXCLUDE_CURRENT=${LP_ATTACHED_SESSIONS_EXCLUDE_CURRENT:-0}
     LP_ENABLE_LOAD=${LP_ENABLE_LOAD:-1}
     LP_ENABLE_BATT=${LP_ENABLE_BATT:-1}
     LP_ENABLE_RAM=${LP_ENABLE_RAM:-1}
@@ -2190,7 +2191,7 @@ _lp_multiplexer() { # [--internal]
     if [[ ${1-} == "--internal" ]]; then
         (( LP_ENABLE_SCREEN_TITLE || LP_ENABLE_TMUX_TITLE_PANES )) || return 2
     else
-        (( LP_ENABLE_MULTIPLEXER )) || return 2
+        (( ${LP_ENABLE_MULTIPLEXER:-1} )) || return 2
     fi
 
     if [[ -n ${TMUX-} ]]; then
@@ -2904,6 +2905,11 @@ _lp_attached_sessions() {
     (( _LP_ENABLE_TMUX )) && count+=$(tmux list-sessions 2> /dev/null | GREP_OPTIONS='' \grep -c '(attached)$')
     (( _LP_ENABLE_SHPOOL )) && count+=$(shpool list 2> /dev/null | GREP_OPTIONS='' \grep -c '[[:space:]]attached$')
     (( _LP_ENABLE_HERDR )) && count+=$(herdr session list 2> /dev/null | GREP_OPTIONS='' \grep -c '[[:space:]]\(running\|attached\)\([[:space:]]\|$\)')
+
+    if (( ${LP_ATTACHED_SESSIONS_EXCLUDE_CURRENT:-0} )) && _lp_multiplexer && (( count > 0 )); then
+        (( count-- ))
+    fi
+
     lp_attached_sessions=$count
 
     (( lp_attached_sessions ))

--- a/liquidprompt
+++ b/liquidprompt
@@ -630,7 +630,6 @@ __lp_source_config() {
     LP_ENABLE_JOBS=${LP_ENABLE_JOBS:-1}
     LP_ENABLE_DETACHED_SESSIONS=${LP_ENABLE_DETACHED_SESSIONS:-1}
     LP_ENABLE_ATTACHED_SESSIONS=${LP_ENABLE_ATTACHED_SESSIONS:-0}
-    LP_ATTACHED_SESSIONS_EXCLUDE_CURRENT=${LP_ATTACHED_SESSIONS_EXCLUDE_CURRENT:-0}
     LP_ENABLE_LOAD=${LP_ENABLE_LOAD:-1}
     LP_ENABLE_BATT=${LP_ENABLE_BATT:-1}
     LP_ENABLE_RAM=${LP_ENABLE_RAM:-1}
@@ -2906,7 +2905,7 @@ _lp_attached_sessions() {
     (( _LP_ENABLE_SHPOOL )) && count+=$(shpool list 2> /dev/null | GREP_OPTIONS='' \grep -c '[[:space:]]attached$')
     (( _LP_ENABLE_HERDR )) && count+=$(herdr session list 2> /dev/null | GREP_OPTIONS='' \grep -c '[[:space:]]\(running\|attached\)\([[:space:]]\|$\)')
 
-    if (( ${LP_ATTACHED_SESSIONS_EXCLUDE_CURRENT:-0} )) && _lp_multiplexer && (( count > 0 )); then
+    if _lp_multiplexer && (( count > 0 )); then
         (( count-- ))
     fi
 

--- a/tests/test_attached_sessions.sh
+++ b/tests/test_attached_sessions.sh
@@ -9,7 +9,6 @@ fi
 . ../liquidprompt --no-activate
 
 LP_ENABLE_ATTACHED_SESSIONS=1
-LP_ATTACHED_SESSIONS_EXCLUDE_CURRENT=0
 LP_ENABLE_MULTIPLEXER=1
 LP_ENABLE_DETACHED_SESSIONS=1
 LP_ENABLE_JOBS=1
@@ -18,6 +17,11 @@ _LP_ENABLE_SCREEN=1
 _LP_ENABLE_TMUX=1
 _LP_ENABLE_SHPOOL=1
 _LP_ENABLE_HERDR=1
+
+function setUp {
+  unset TMUX SHPOOL_SESSION_NAME HERDR_SESSION HERDR_SESSION_NAME HERDR_ENV
+  TERM=dumb
+}
 
 typeset -a screen_outputs screen_values shpool_outputs shpool_values tmux_outputs tmux_values herdr_outputs herdr_values
 
@@ -213,36 +217,40 @@ h2     attached
 "
   }
 
-  LP_ATTACHED_SESSIONS_EXCLUDE_CURRENT=0
-  TMUX=1
-  _lp_attached_sessions
-  assertEquals "Count all attached when EXCLUDE_CURRENT=0" "8" "$lp_attached_sessions"
-
-  LP_ATTACHED_SESSIONS_EXCLUDE_CURRENT=1
+  # 1. Inside tmux (subtract 1)
   TMUX=1
   _lp_attached_sessions
   assertEquals "Exclude current session inside tmux" "7" "$lp_attached_sessions"
 
+  # 2. Inside screen (subtract 1)
   unset TMUX
   TERM=screen-256color
   _lp_attached_sessions
   assertEquals "Exclude current session inside screen" "7" "$lp_attached_sessions"
 
+  # 3. Inside shpool (subtract 1)
   TERM=dumb
   SHPOOL_SESSION_NAME=s1
   _lp_attached_sessions
   assertEquals "Exclude current session inside shpool" "7" "$lp_attached_sessions"
 
+  # 4. Inside herdr (subtract 1)
   unset SHPOOL_SESSION_NAME
   HERDR_SESSION=h1
   _lp_attached_sessions
   assertEquals "Exclude current session inside herdr" "7" "$lp_attached_sessions"
 
+  # 5. Outside any multiplexer (do not subtract)
   unset HERDR_SESSION HERDR_SESSION_NAME HERDR_ENV
   _lp_attached_sessions
   assertEquals "Do not exclude current session when outside multiplexer" "8" "$lp_attached_sessions"
 
-  LP_ATTACHED_SESSIONS_EXCLUDE_CURRENT=0
+  # 6. Inside tmux but LP_ENABLE_MULTIPLEXER=0 (multiplexer detection disabled, do not subtract)
+  TMUX=1
+  LP_ENABLE_MULTIPLEXER=0
+  _lp_attached_sessions
+  assertEquals "Do not exclude current session when LP_ENABLE_MULTIPLEXER=0" "8" "$lp_attached_sessions"
+  LP_ENABLE_MULTIPLEXER=1
 }
 
 . ./shunit2

--- a/tests/test_attached_sessions.sh
+++ b/tests/test_attached_sessions.sh
@@ -9,6 +9,8 @@ fi
 . ../liquidprompt --no-activate
 
 LP_ENABLE_ATTACHED_SESSIONS=1
+LP_ATTACHED_SESSIONS_EXCLUDE_CURRENT=0
+LP_ENABLE_MULTIPLEXER=1
 LP_ENABLE_DETACHED_SESSIONS=1
 LP_ENABLE_JOBS=1
 LP_MARK_JOBS_SEPARATOR="/"
@@ -186,6 +188,61 @@ sub    detached
   NO_COL=""
   _lp_jobcount_color
   assertEquals "Jobcount color with attached and detached sessions" "[D]1d/[A]1r" "$lp_jobcount_color"
+}
+
+function test_attached_sessions_exclude_current {
+  tmux() {
+    printf '%s' "0: 1 windows [179x96] (attached)
+1: 1 windows [179x96] (attached)
+"
+  }
+  screen() {
+    printf '%s' "	12345.pts-0.host	(08/14/2026 10:00:00 AM)	(Attached)
+	12346.pts-1.host	(08/14/2026 10:00:00 AM)	(Attached)
+"
+  }
+  shpool() {
+    printf '%s' "s1	attached
+s2	attached
+"
+  }
+  herdr() {
+    printf '%s' "NAME   STATUS
+h1     attached
+h2     attached
+"
+  }
+
+  LP_ATTACHED_SESSIONS_EXCLUDE_CURRENT=0
+  TMUX=1
+  _lp_attached_sessions
+  assertEquals "Count all attached when EXCLUDE_CURRENT=0" "8" "$lp_attached_sessions"
+
+  LP_ATTACHED_SESSIONS_EXCLUDE_CURRENT=1
+  TMUX=1
+  _lp_attached_sessions
+  assertEquals "Exclude current session inside tmux" "7" "$lp_attached_sessions"
+
+  unset TMUX
+  TERM=screen-256color
+  _lp_attached_sessions
+  assertEquals "Exclude current session inside screen" "7" "$lp_attached_sessions"
+
+  TERM=dumb
+  SHPOOL_SESSION_NAME=s1
+  _lp_attached_sessions
+  assertEquals "Exclude current session inside shpool" "7" "$lp_attached_sessions"
+
+  unset SHPOOL_SESSION_NAME
+  HERDR_SESSION=h1
+  _lp_attached_sessions
+  assertEquals "Exclude current session inside herdr" "7" "$lp_attached_sessions"
+
+  unset HERDR_SESSION HERDR_SESSION_NAME HERDR_ENV
+  _lp_attached_sessions
+  assertEquals "Do not exclude current session when outside multiplexer" "8" "$lp_attached_sessions"
+
+  LP_ATTACHED_SESSIONS_EXCLUDE_CURRENT=0
 }
 
 . ./shunit2


### PR DESCRIPTION
## Description

When running inside an active multiplexer session (`tmux`, `screen`, `shpool`, or `herdr`), `_lp_multiplexer()` already indicates the active multiplexer context in the prompt. Displaying `1r` for the session currently occupied is redundant.

This PR makes `_lp_attached_sessions()` automatically subtract the current session context when `_lp_multiplexer` is active:
- **Outside multiplexer:** Displays all attached sessions on the host (`1r`, `2r`, etc.).
- **Inside multiplexer with 1 attached session (itself):** Hidden (`0r`).
- **Inside multiplexer with 2 attached sessions (itself + 1 other):** Displays `1r`.

# Technical checklist:

- code follows our [shell standards](https://github.com/liquidprompt/liquidprompt/wiki/Shell-standards):
    - [x] correct use of `IFS`
    - [x] careful quoting
    - [x] cautious array access
    - [x] portable array indexing with `_LP_FIRST_INDEX`
    - [x] printing a "%" character is done with `_LP_PERCENT`
    - [x] functions/variable naming conventions
    - [x] functions have local variables
    - [x] data functions have optimization guards (early exits)
    - [x] subshells are avoided as much as possible
    - [x] string substitutions may be done differently in Bash and Zsh (use `_LP_SHELL_*`)
- tests and checks have been added, run, and their warnings fixed:
    - [x] unit tests have been updated (`tests/test_attached_sessions.sh`)
    - [x] ran `tests.sh`
    - [x] ran `shellcheck.sh`
- documentation has been updated accordingly:
    - [x] functions and attributes are documented in alphabetical order
    - [x] new sections are documented in the default theme
    - [x] tag `.. versionadded:: 2.4`
    - [x] function signatures have arguments, returned code, and set value(s)
    - [x] attributes have types and defaults
    - [x] ran `docs/docs-lint.sh` (0 errors)